### PR TITLE
ci(publish): switch from NPM_TOKEN to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,7 +70,12 @@ jobs:
           fi
           echo "Version verified: $PKG_VERSION"
 
-      - name: Publish to npm (with provenance attestation)
+      # Authentication: npm Trusted Publishing via OIDC.
+      # The workflow already requests `id-token: write` (line 12) and Setup
+      # Node.js wrote a `.npmrc` pointing at the official registry, so pnpm
+      # publish exchanges the GitHub OIDC token for a short-lived npm access
+      # token automatically — no NPM_TOKEN secret needed. The publisher must
+      # be registered on the npm package page first:
+      #   https://www.npmjs.com/package/@tantainnovative/ndpr-toolkit/access
+      - name: Publish to npm (Trusted Publishing + provenance attestation)
         run: pnpm publish --no-git-checks --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

3.5.5's publish job failed at the final step with `404 Not Found` on `PUT https://registry.npmjs.org/@tantainnovative%2fndpr-toolkit` — npm's misleading way of saying the `NPM_TOKEN` lacks write access to the scope. Provenance signing succeeded (sigstore log index 1624379731) before the upload was rejected.

Switching to **npm Trusted Publishing via GitHub OIDC** removes the token entirely. The workflow already requests `id-token: write`, so `pnpm publish --provenance` performs the OIDC handshake natively. Pairs cleanly with provenance attestation and removes the long-lived secret to rotate.

## What you need to do on the npm side (before merging this PR)

1. Visit https://www.npmjs.com/package/@tantainnovative/ndpr-toolkit/access
2. Scroll to **"Trusted publishers"** → click **"Add trusted publisher"**
3. Choose **GitHub Actions** as the publisher
4. Fill in:
   - **Organization or user:** `mr-tanta`
   - **Repository:** `ndpr-toolkit`
   - **Workflow filename:** `publish.yml`
   - **Environment:** leave blank
5. Save. The publisher is now whitelisted.

## What happens after merge

1. The `NPM_TOKEN` secret becomes unused. You can revoke it at https://www.npmjs.com/settings/abrahamtanta/tokens (optional but recommended hygiene).
2. Re-run the failed publish workflow from https://github.com/mr-tanta/ndpr-toolkit/actions (the v3.5.5 release is already created — just dispatch the workflow again or recreate the release).

## Test plan

- [ ] You: register the trusted publisher on npm
- [ ] You: approve + merge this PR
- [ ] Me: re-trigger the publish workflow and confirm `npm view @tantainnovative/ndpr-toolkit version` shows `3.5.5`
- [ ] Optional: revoke the now-unused `NPM_TOKEN` secret + the npm-side token