### PR TITLE
ci(publish): use npm publish (pnpm doesn't call npm's OIDC token exchange)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,11 +71,17 @@ jobs:
           echo "Version verified: $PKG_VERSION"
 
       # Authentication: npm Trusted Publishing via OIDC.
-      # The workflow already requests `id-token: write` (line 12) and Setup
-      # Node.js wrote a `.npmrc` pointing at the official registry, so pnpm
-      # publish exchanges the GitHub OIDC token for a short-lived npm access
-      # token automatically — no NPM_TOKEN secret needed. The publisher must
-      # be registered on the npm package page first:
+      # Uses `npm publish` (not `pnpm publish`) because pnpm doesn't yet
+      # implement npm's `/auth/oidc` token-exchange endpoint. `npm publish`
+      # picks up the GitHub OIDC token via the `id-token: write` permission
+      # above and the registry .npmrc that actions/setup-node wrote, then
+      # exchanges it for a short-lived npm token. No NPM_TOKEN needed.
+      #
+      # Requires a registered trusted publisher at:
       #   https://www.npmjs.com/package/@tantainnovative/ndpr-toolkit/access
+      #
+      # `--provenance` adds the sigstore attestation; both pnpm and npm
+      # publish support that flag identically.
       - name: Publish to npm (Trusted Publishing + provenance attestation)
-        run: pnpm publish --no-git-checks --access public --provenance
+        working-directory: .
+        run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary

Two consecutive publishes of v3.5.5 failed at the npm registry PUT with the same 404, even after switching to npm Trusted Publishing. Provenance signing succeeded both times (sigstore logs 1624379731 and 1624436654 contain the attestations), but the registry kept rejecting the upload as if no auth were present.

Root cause: **pnpm publish doesn't implement npm's `/auth/oidc` token-exchange endpoint.** That endpoint is what converts the GitHub OIDC token into a short-lived npm token. `pnpm publish --provenance` does the sigstore part (which works for both pnpm and npm) but never calls the npm-side OIDC exchange, so the publish still arrives at the registry unauthenticated — hence the 404.

`npm publish` does the exchange natively. This PR switches just the publish step (everything else stays on pnpm).

## Test plan

- [ ] Approve + merge this PR
- [ ] Delete + recreate the v3.5.5 release to re-fire publish.yml
- [ ] Confirm `npm view @tantainnovative/ndpr-toolkit version` shows 3.5.5