### PR TITLE
ci(publish): upgrade npm to latest before publish (Trusted Publishing needs npm >=11.5.1)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,14 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
+      - name: Upgrade npm to a version that supports Trusted Publishing OIDC
+        # Node 22 ships with npm 10.x; npm Trusted Publishing (the GitHub
+        # OIDC → npm token exchange) requires npm 11.5.1 or later. Without
+        # this step, `npm publish --provenance` signs the sigstore
+        # attestation but never exchanges the OIDC token, then hits the
+        # registry unauthenticated and gets a misleading 404.
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
 


### PR DESCRIPTION
## Root cause confirmed for the v3.5.5 publish failures

Three consecutive publishes of v3.5.5 returned `404 Not Found` on the registry PUT. Provenance signing succeeded each time (sigstore log indices 1624379731, 1624436654, 1624460478). What was missing: the npm-side OIDC token exchange.

Node 22 ships with **npm 10.x**. npm Trusted Publishing's OIDC → npm-token exchange — the part that converts the GitHub OIDC token into a short-lived publish token by calling npm's `/auth/oidc` endpoint — **requires npm CLI 11.5.1 or later**. With npm 10, `npm publish --provenance` signs the sigstore attestation (which only depends on GitHub OIDC, supported in old npm) but never exchanges the OIDC token. The publish then arrives at the registry unauthenticated and the registry returns a misleading 404.

## The fix

One added step before the publish:

```yaml
- name: Upgrade npm to a version that supports Trusted Publishing OIDC
  run: npm install -g npm@latest
```

## Test plan

- [ ] CI green
- [ ] Merge this PR
- [ ] Delete + recreate v3.5.5 release to refire publish.yml
- [ ] `npm view @tantainnovative/ndpr-toolkit version` shows 3.5.5
- [ ] Confirm "Provenance" badge appears on the npm package page