### PR TITLE
feat(docs): 3.5.6 — SEO sweep (Nigeria disambiguation + JSON-LD + long-tail landing pages)

### DIFF
--- a/src/app/docs/components/layout.tsx
+++ b/src/app/docs/components/layout.tsx
@@ -1,33 +1,34 @@
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Components Reference | NDPA Toolkit',
+  title: 'Nigeria NDPA Components — React API Reference',
   description:
-    'Browse all NDPA Toolkit components: consent banners, DSR portals, DPIA tools, breach workflows, and more. Build NDPC-compliant apps faster.',
+    'API reference for every NDPR Toolkit React component: cookie consent banner, DSR portal, DPIA questionnaire, 72-hour breach notification, RoPA, lawful-basis tracker, privacy-policy generator. NDPA 2023 compliant.',
   keywords:
-    'NDPA components, Nigeria Data Protection components, NDPC compliance React, NDPA toolkit API, data protection UI components',
+    'Nigeria NDPA components, NDPA React API, Nigeria cookie consent component, Nigeria DSR React, Nigeria DPIA React, Nigeria breach notification component, NDPC compliance components',
+  alternates: { canonical: '/docs/components' },
   openGraph: {
-    title: 'Components Reference | NDPA Toolkit',
+    title: 'Nigeria NDPA Components — React API Reference',
     description:
-      'Browse all NDPA Toolkit components: consent banners, DSR portals, DPIA tools, breach workflows, and more. Build NDPC-compliant apps faster.',
+      'Every NDPR Toolkit component: cookie consent, DSR portal, DPIA, 72-hour breach notification, RoPA, privacy-policy generator. Built for Nigeria NDPA 2023.',
     url: 'https://ndprtoolkit.com.ng/docs/components',
-    siteName: 'NDPA Toolkit',
+    siteName: 'NDPR Toolkit',
     images: [
       {
         url: '/og-image.png',
         width: 1200,
         height: 630,
-        alt: 'NDPA Toolkit Components Reference',
+        alt: 'NDPR Toolkit — Nigeria NDPA Components Reference',
       },
     ],
-    locale: 'en_US',
+    locale: 'en_NG',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Components Reference | NDPA Toolkit',
+    title: 'Nigeria NDPA Components — React API Reference',
     description:
-      'Browse all NDPA Toolkit components: consent banners, DSR portals, DPIA tools, breach workflows, and more. Build NDPC-compliant apps faster.',
+      'Cookie consent, DSR portal, DPIA, breach notification, RoPA, and privacy-policy generator components for Nigeria NDPA 2023.',
     images: ['/og-image.png'],
   },
 };

--- a/src/app/docs/metadata.ts
+++ b/src/app/docs/metadata.ts
@@ -1,33 +1,34 @@
 import { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Documentation | NDPA Toolkit',
+  title: 'Nigeria NDPA 2023 Documentation — React & Next.js',
   description:
-    'Comprehensive NDPA 2023 compliance docs: component API reference, implementation guides, and NDPC best practices. Start building compliant apps now.',
+    'Documentation for the NDPR Toolkit: a React/TypeScript library for Nigeria Data Protection Act (NDPA) 2023 compliance. Component API, integration guides, and NDPC best practices for Nigerian fintech, insurtech, and SaaS.',
   keywords:
-    'NDPA documentation, Nigeria Data Protection docs, NDPC compliance guide, NDPA 2023 API reference, data protection implementation',
+    'Nigeria NDPA documentation, Nigeria Data Protection Act 2023 React, NDPR documentation, NDPC compliance guide, Nigeria privacy policy React, Nigeria cookie consent docs, Nigeria DPIA implementation',
+  alternates: { canonical: '/docs' },
   openGraph: {
-    title: 'Documentation | NDPA Toolkit',
+    title: 'Nigeria NDPA 2023 Documentation — NDPR Toolkit',
     description:
-      'Comprehensive NDPA 2023 compliance docs: component API reference, implementation guides, and NDPC best practices. Start building compliant apps now.',
+      'React & TypeScript docs for Nigeria NDPA 2023 compliance: consent, DSR, DPIA, breach notification, RoPA, and privacy-policy generator. Built for Nigerian apps.',
     url: 'https://ndprtoolkit.com.ng/docs',
-    siteName: 'NDPA Toolkit',
+    siteName: 'NDPR Toolkit',
     images: [
       {
         url: '/og-docs.png',
         width: 1200,
         height: 630,
-        alt: 'NDPA Toolkit Documentation',
+        alt: 'NDPR Toolkit — Nigeria NDPA Documentation',
       },
     ],
-    locale: 'en_US',
+    locale: 'en_NG',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Documentation | NDPA Toolkit',
+    title: 'Nigeria NDPA 2023 Documentation — NDPR Toolkit',
     description:
-      'Comprehensive NDPA 2023 compliance docs: component API reference, implementation guides, and NDPC best practices. Start building compliant apps now.',
+      'React/TypeScript docs for Nigeria NDPA 2023 compliance: consent, DSR, DPIA, breach, RoPA, privacy policy.',
     images: ['/og-docs.png'],
   },
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,13 +18,16 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   metadataBase: new URL("https://ndprtoolkit.com.ng"),
   title: {
-    default: "NDPA Toolkit — NDPA 2023 Compliance Infrastructure for React",
-    template: "%s | NDPA Toolkit",
+    default: "NDPR Toolkit — Nigeria Data Protection Act (NDPA) 2023 Library for React & Next.js",
+    template: "%s | NDPR Toolkit (Nigeria NDPA)",
   },
   description:
-    "v3 — Production-ready React components and adapters for NDPA 2023 compliance. Consent management, DSR portal, DPIA, breach notification, compliance score, and presets for Nigerian applications.",
+    "Open-source React & TypeScript library for Nigeria Data Protection Act (NDPA) 2023 compliance. Cookie consent banner, data-subject rights portal, DPIA, 72-hour breach notification, RoPA, lawful-basis tracker, and privacy-policy generator — built for Nigerian fintech, insurtech, and SaaS.",
   keywords:
-    "NDPA, NDPA 2023, Nigeria Data Protection Act, NDPC, compliance toolkit, React, Next.js, open source, compliance score, adapters, presets, DSR portal",
+    "Nigeria NDPA, NDPA 2023, Nigeria Data Protection Act, NDPR, NDPC, Nigeria cookie consent, Nigeria privacy policy generator, Nigeria DPIA tool, Nigeria GDPR, NDPC compliance, Nigerian fintech compliance, React, Next.js, TypeScript, open source",
+  alternates: {
+    canonical: "/",
+  },
   applicationName: "NDPA Toolkit",
   manifest: "/favicon/site.webmanifest",
   icons: {
@@ -47,30 +50,90 @@ export const metadata: Metadata = {
     "theme-color": "#1d4ed8",
   },
   openGraph: {
-    title: "NDPA Toolkit — NDPA 2023 Compliance Infrastructure for React",
+    title: "NDPR Toolkit — Nigeria Data Protection Act (NDPA) 2023 Library for React",
     description:
-      "v3 — Production-ready React components and adapters for NDPA 2023 compliance. Consent management, DSR portal, DPIA, breach notification, compliance score, and presets for Nigerian applications.",
+      "Open-source React & TypeScript library for Nigeria NDPA 2023 compliance. Cookie consent, DSR portal, DPIA, 72-hour breach notification, RoPA, and privacy-policy generator built for Nigerian fintech, insurtech, and SaaS.",
     type: "website",
-    siteName: "NDPA Toolkit",
-    locale: "en_US",
+    siteName: "NDPR Toolkit",
+    locale: "en_NG",
     url: "https://ndprtoolkit.com.ng",
     images: [
       {
         url: "/og-image.png",
         width: 1200,
         height: 630,
-        alt: "NDPA Toolkit — NDPA 2023 Compliance Infrastructure for React",
+        alt: "NDPR Toolkit — Nigeria Data Protection Act 2023 Library for React",
       },
     ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "NDPA Toolkit — NDPA 2023 Compliance Infrastructure for React",
+    title: "NDPR Toolkit — Nigeria NDPA 2023 Library for React & Next.js",
     description:
-      "v3 — Production-ready React toolkit for NDPA 2023: adapters, presets, compliance score, consent management, DSR, DPIA, and breach notification for Nigerian applications.",
+      "Open-source React/TypeScript library for Nigeria NDPA 2023 compliance: consent, DSR, DPIA, breach notification, RoPA, lawful-basis, privacy policy. MIT-licensed.",
     images: ["/og-image.png"],
     creator: "@mr_tanta",
   },
+};
+
+// Site-wide JSON-LD. Lets Google emit a rich SoftwareApplication snippet
+// (app category, license, OS, free pricing) on the homepage and helps
+// disambiguate "NDPA" from Nebraska in search results. The TechArticle
+// schemas on individual /docs pages stack on top of this.
+//
+// Note: JSON-LD is the documented Next.js pattern for structured data and
+// the content is a fully static, server-rendered constant (no user input),
+// so `dangerouslySetInnerHTML` cannot produce an XSS vector here. See
+// https://nextjs.org/learn/seo/structured-data
+const softwareApplicationJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: "NDPR Toolkit",
+  alternateName: [
+    "NDPA Toolkit",
+    "Nigeria Data Protection Toolkit",
+    "@tantainnovative/ndpr-toolkit",
+  ],
+  applicationCategory: "DeveloperApplication",
+  applicationSubCategory: "Privacy & Compliance",
+  operatingSystem: "Cross-platform (Browser, Node.js, Next.js, Edge)",
+  description:
+    "Open-source React and TypeScript library for Nigeria Data Protection Act (NDPA) 2023 compliance: cookie consent, data-subject rights portal, DPIA, 72-hour breach notification, RoPA, lawful-basis tracker, and privacy-policy generator.",
+  url: "https://ndprtoolkit.com.ng",
+  downloadUrl: "https://www.npmjs.com/package/@tantainnovative/ndpr-toolkit",
+  softwareVersion: "3.5.5",
+  license: "https://opensource.org/licenses/MIT",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+  },
+  author: {
+    "@type": "Person",
+    name: "Abraham Esandayinze Tanta",
+    url: "https://linkedin.com/in/mr-tanta",
+  },
+  publisher: {
+    "@type": "Organization",
+    name: "Tanta Innovatives",
+    url: "https://tantainnovatives.com",
+  },
+  keywords:
+    "Nigeria NDPA, NDPA 2023, Nigeria Data Protection Act, NDPR, NDPC, Nigeria cookie consent, Nigeria privacy policy generator, Nigeria DPIA tool, React, Next.js, TypeScript",
+  inLanguage: ["en", "en-NG", "yo", "ig", "ha", "pcm"],
+};
+
+const organizationJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "Tanta Innovatives",
+  url: "https://tantainnovatives.com",
+  logo: "https://ndprtoolkit.com.ng/icon-blue.png",
+  sameAs: [
+    "https://github.com/mr-tanta/ndpr-toolkit",
+    "https://www.npmjs.com/package/@tantainnovative/ndpr-toolkit",
+    "https://linkedin.com/in/mr-tanta",
+  ],
 };
 
 export default function RootLayout({
@@ -79,7 +142,22 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="dark">
+    <html lang="en-NG" className="dark">
+      <head>
+        {/* Static, server-rendered JSON-LD — safe to inject. */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(softwareApplicationJsonLd),
+          }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(organizationJsonLd),
+          }}
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/src/app/ndpa-dpia-tool/page.tsx
+++ b/src/app/ndpa-dpia-tool/page.tsx
@@ -1,0 +1,157 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { SiteHeader } from '@/components/site/SiteHeader';
+import { SiteFooter } from '@/components/site/SiteFooter';
+
+export const metadata: Metadata = {
+  title: 'Nigeria DPIA Tool — Section 28 Data Privacy Impact Assessment',
+  description:
+    'Free, open-source Data Privacy Impact Assessment (DPIA) tool for Nigeria NDPA 2023 Section 28. Stepped questionnaire, risk scoring, mitigation tracking, NDPC consultation flag, PDF/DOCX export. Drop-in React component with a typed hook for custom UIs.',
+  keywords:
+    'Nigeria DPIA tool, NDPA Section 28 DPIA, NDPR DPIA, NDPC DPIA consultation, Nigeria DPIA template, Data Privacy Impact Assessment Nigeria, Nigeria high-risk processing assessment',
+  alternates: { canonical: '/ndpa-dpia-tool' },
+  openGraph: {
+    title: 'Nigeria DPIA Tool — NDPA 2023 Section 28 Compliant',
+    description:
+      'Free open-source DPIA tool for Nigeria NDPA 2023 Section 28. Stepped questionnaire, risk scoring, mitigation tracking, NDPC consultation flag, PDF/DOCX export.',
+    url: 'https://ndprtoolkit.com.ng/ndpa-dpia-tool',
+    siteName: 'NDPR Toolkit',
+    images: [
+      {
+        url: '/og-image.png',
+        width: 1200,
+        height: 630,
+        alt: 'Nigeria NDPA DPIA Tool — Section 28',
+      },
+    ],
+    locale: 'en_NG',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Nigeria DPIA Tool — NDPA 2023 Section 28',
+    description:
+      'Free open-source DPIA tool for Nigeria NDPA 2023. Questionnaire, risk scoring, mitigation, NDPC consultation flag, PDF/DOCX export.',
+    images: ['/og-image.png'],
+  },
+};
+
+// Static, server-rendered JSON-LD — no user input — safe to inject.
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'NDPR Toolkit DPIA Questionnaire',
+  applicationCategory: 'DeveloperApplication',
+  applicationSubCategory: 'Privacy & Compliance · DPIA',
+  operatingSystem: 'Cross-platform (Browser, Node.js, Next.js, Edge)',
+  description:
+    'Open-source Data Privacy Impact Assessment tool for Nigeria NDPA 2023 Section 28. Stepped questionnaire, weighted risk scoring, mitigation tracking, NDPC prior-consultation flag, and PDF/DOCX export.',
+  url: 'https://ndprtoolkit.com.ng/ndpa-dpia-tool',
+  downloadUrl: 'https://www.npmjs.com/package/@tantainnovative/ndpr-toolkit',
+  license: 'https://opensource.org/licenses/MIT',
+  offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  keywords: 'Nigeria DPIA tool, NDPA Section 28, Nigeria DPIA template',
+};
+
+export default function NDPADPIAToolLanding() {
+  return (
+    <>
+      <SiteHeader />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <main className="min-h-screen max-w-4xl mx-auto px-6 py-16">
+        <header className="mb-12">
+          <p className="text-sm font-medium uppercase tracking-wider text-muted-foreground mb-3">
+            NDPA Section 28 · Free · Open source
+          </p>
+          <h1 className="text-4xl md:text-5xl font-bold text-foreground mb-6">
+            Nigeria DPIA Tool &mdash;{' '}
+            <span className="text-primary">NDPA Section 28 Compliant</span>
+          </h1>
+          <p className="text-xl text-muted-foreground leading-relaxed">
+            A complete Data Privacy Impact Assessment workflow for Nigeria&apos;s Data
+            Protection Act 2023. Stepped questionnaire, weighted risk scoring,
+            mitigation tracking, NDPC prior-consultation flag, and PDF/DOCX
+            export &mdash; all as a typed React component or a headless hook
+            you can wrap in your own UI.
+          </p>
+          <div className="flex flex-wrap gap-3 mt-8">
+            <Link href="/docs/components/dpia-questionnaire" className="inline-flex items-center gap-2 px-5 py-3 rounded-lg bg-primary text-primary-foreground font-medium hover:opacity-90">Read the docs →</Link>
+            <Link href="/ndpr-demos/dpia" className="inline-flex items-center gap-2 px-5 py-3 rounded-lg border border-border text-foreground font-medium hover:bg-card">Try the live demo</Link>
+          </div>
+        </header>
+
+        <section className="prose prose-invert max-w-none mb-12">
+          <h2 className="text-2xl font-bold mb-4">When do I need a DPIA under Nigerian law?</h2>
+          <p>
+            NDPA 2023 Section 28(1) requires a Data Privacy Impact Assessment <em>before</em> any
+            processing that is likely to result in a high risk to the rights and freedoms of data
+            subjects. The NDPC has emphasised DPIAs as a precondition for licensed Data Controllers
+            and Processors of Major Importance (DCPMI) under Section 32. In practice, that covers:
+          </p>
+          <ul className="list-disc pl-6 space-y-1">
+            <li>Large-scale processing of <strong>sensitive personal data</strong> (Section 30) &mdash; health, biometric, financial, religious, political, ethnic, children.</li>
+            <li>Systematic monitoring of publicly accessible areas (CCTV, surveillance, geo-location).</li>
+            <li>Automated decision-making with legal or similarly significant effects (Section 37 territory).</li>
+            <li>Combining datasets in ways data subjects would not reasonably expect.</li>
+            <li>Any processing the NDPC has formally designated high-risk in subsidiary guidance.</li>
+          </ul>
+          <p>
+            Under Section 28(2), if residual risk after mitigation remains high, the controller
+            <strong> must consult the NDPC</strong> before proceeding. The DPIA tool surfaces this
+            consultation requirement automatically as part of the result.
+          </p>
+
+          <h2 className="text-2xl font-bold mt-10 mb-4">What the tool does</h2>
+          <ul className="list-disc pl-6 space-y-2">
+            <li><strong>Stepped questionnaire</strong> &mdash; multi-section flow covering project overview, data flows, data subjects, lawful basis, risks, and mitigations. Progress indicator + per-section validation.</li>
+            <li><strong>Weighted risk scoring</strong> &mdash; each risk gets a likelihood × severity score; mitigated risks reduce the residual level.</li>
+            <li><strong>NDPC consultation flag</strong> &mdash; the result returns <code>requiresConsultation: true</code> when residual risk is high or critical, matching Section 28(2).</li>
+            <li><strong>Audit-friendly output</strong> &mdash; deterministic PDF + DOCX export with the legal notice footer the NDPR Toolkit ships everywhere.</li>
+            <li><strong>Headless mode</strong> &mdash; if the default UI is too opinionated, use the <code>useDPIA</code> hook + <code>DPIAProvider</code> compound API and build your own.</li>
+            <li><strong>Persistence</strong> &mdash; long DPIAs save progress via any <code>StorageAdapter</code> (localStorage by default).</li>
+          </ul>
+
+          <h2 className="text-2xl font-bold mt-10 mb-4">Install</h2>
+          <pre className="bg-card border border-border rounded-lg p-4 overflow-x-auto"><code className="text-sm">{`pnpm add @tantainnovative/ndpr-toolkit`}</code></pre>
+          <p>Drop the preset into any client component:</p>
+          <pre className="bg-card border border-border rounded-lg p-4 overflow-x-auto"><code className="text-sm">{`// app/dpia/page.tsx
+'use client';
+import { NDPRDPIA } from '@tantainnovative/ndpr-toolkit/presets';
+
+export default function DPIAPage() {
+  return (
+    <NDPRDPIA
+      onComplete={(answers) => {
+        fetch('/api/dpia', { method: 'POST', body: JSON.stringify(answers) });
+      }}
+    />
+  );
+}`}</code></pre>
+
+          <h2 className="text-2xl font-bold mt-10 mb-4">Built for Nigerian compliance teams</h2>
+          <p>
+            Every label, section reference, and consultation prompt is derived from the gazetted
+            text of the NDPA 2023 (not GDPR, not Nebraska&apos;s NDPA). Section numbers are
+            consistent with the Act as published &mdash; if NDPC issues subsidiary guidance that
+            changes thresholds, the toolkit&apos;s open-source repo accepts PRs from privacy
+            practitioners.
+          </p>
+        </section>
+
+        <section className="border-t border-border pt-12">
+          <h2 className="text-2xl font-bold mb-6">Related</h2>
+          <ul className="space-y-3">
+            <li><Link href="/docs/components/dpia-questionnaire" className="text-primary hover:underline">DPIA Questionnaire — full API reference</Link></li>
+            <li><Link href="/docs/guides/conducting-dpia" className="text-primary hover:underline">Guide — conducting a DPIA under Section 28</Link></li>
+            <li><Link href="/ndpr-demos/dpia" className="text-primary hover:underline">Interactive live demo</Link></li>
+            <li><Link href="/docs/components/breach-notification" className="text-primary hover:underline">Breach notification — 72-hour countdown</Link></li>
+          </ul>
+        </section>
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/src/app/ndpr-demos/layout.tsx
+++ b/src/app/ndpr-demos/layout.tsx
@@ -3,33 +3,34 @@ import { SiteHeader } from '@/components/site/SiteHeader';
 import { SiteFooter } from '@/components/site/SiteFooter';
 
 export const metadata: Metadata = {
-  title: 'Interactive NDPA Demos | NDPA Toolkit',
+  title: 'Live Nigeria NDPA 2023 Compliance Demos — Try in Browser',
   description:
-    'Explore 8 interactive demos for NDPA 2023 compliance: consent management, DSR, DPIA, breach notification, and more. Try the NDPA Toolkit free.',
+    'Eight interactive demos for Nigeria NDPA 2023 compliance — cookie consent, DSR portal, DPIA questionnaire, 72-hour breach notification, RoPA, lawful-basis tracker, cross-border transfers, and privacy-policy generator. No install required.',
   keywords:
-    'NDPA demos, Nigeria Data Protection, NDPC compliance, NDPA 2023, interactive compliance tools',
+    'Nigeria NDPA demo, Nigeria cookie consent demo, Nigeria DSR demo, Nigeria DPIA tool, Nigeria breach notification demo, NDPC compliance demo, NDPA 2023 React demo',
+  alternates: { canonical: '/ndpr-demos' },
   openGraph: {
-    title: 'Interactive NDPA Demos | NDPA Toolkit',
+    title: 'Live Nigeria NDPA 2023 Compliance Demos — Try in Browser',
     description:
-      'Explore 8 interactive demos for NDPA 2023 compliance: consent management, DSR, DPIA, breach notification, and more. Try the NDPA Toolkit free.',
+      'Try Nigeria NDPA 2023 compliance components in your browser — consent, DSR, DPIA, breach, RoPA, privacy policy. Zero setup.',
     url: 'https://ndprtoolkit.com.ng/ndpr-demos',
-    siteName: 'NDPA Toolkit',
+    siteName: 'NDPR Toolkit',
     images: [
       {
         url: '/og-image.png',
         width: 1200,
         height: 630,
-        alt: 'NDPA Toolkit Interactive Demos',
+        alt: 'NDPR Toolkit — Live Nigeria NDPA 2023 Demos',
       },
     ],
-    locale: 'en_US',
+    locale: 'en_NG',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Interactive NDPA Demos | NDPA Toolkit',
+    title: 'Live Nigeria NDPA Demos — Try in Browser',
     description:
-      'Explore 8 interactive demos for NDPA 2023 compliance: consent management, DSR, DPIA, breach notification, and more. Try the NDPA Toolkit free.',
+      'Eight zero-setup demos for Nigeria NDPA 2023 compliance: consent, DSR, DPIA, breach, RoPA, privacy policy.',
     images: ['/og-image.png'],
   },
 };

--- a/src/app/nigeria-cookie-consent/page.tsx
+++ b/src/app/nigeria-cookie-consent/page.tsx
@@ -1,0 +1,166 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { SiteHeader } from '@/components/site/SiteHeader';
+import { SiteFooter } from '@/components/site/SiteFooter';
+
+export const metadata: Metadata = {
+  title: 'Nigeria Cookie Consent Banner for React — NDPA 2023 Compliant',
+  description:
+    'Drop-in cookie consent banner for Nigerian websites. NDPA 2023 + GAID 2025 compliant. Supports granular categories (necessary, analytics, marketing, ads, functional), audit log, withdrawal-as-easy-as-consent (Section 26), version-bump re-prompt, and storage adapters for any backend.',
+  keywords:
+    'Nigeria cookie consent, Nigeria cookie banner, NDPA cookie consent, NDPR cookie consent, Nigeria cookie law React, NDPA Section 26 consent, cookie consent Nigerian fintech, Nigeria consent management',
+  alternates: { canonical: '/nigeria-cookie-consent' },
+  openGraph: {
+    title: 'Nigeria Cookie Consent Banner for React — NDPA 2023 Compliant',
+    description:
+      'Drop-in cookie consent banner for Nigerian websites. NDPA 2023 + GAID 2025 compliant. Granular categories, audit log, withdrawal, version-bump re-prompt.',
+    url: 'https://ndprtoolkit.com.ng/nigeria-cookie-consent',
+    siteName: 'NDPR Toolkit',
+    images: [
+      {
+        url: '/og-image.png',
+        width: 1200,
+        height: 630,
+        alt: 'Nigeria NDPA Cookie Consent Banner for React',
+      },
+    ],
+    locale: 'en_NG',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Nigeria Cookie Consent Banner for React — NDPA 2023 Compliant',
+    description:
+      'Drop-in cookie consent banner for Nigerian websites. NDPA 2023 + GAID 2025 compliant.',
+    images: ['/og-image.png'],
+  },
+};
+
+// Static, server-rendered JSON-LD — no user input — safe to inject.
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'NDPR Toolkit Cookie Consent Banner',
+  applicationCategory: 'DeveloperApplication',
+  applicationSubCategory: 'Cookie Consent / CMP',
+  operatingSystem: 'Cross-platform (Browser, Node.js, Next.js, Edge)',
+  description:
+    'NDPA 2023-compliant cookie consent banner for React and Next.js. Supports granular categories, audit log, withdrawal as easy as consent (Section 26), version-bump re-prompt, and pluggable storage adapters.',
+  url: 'https://ndprtoolkit.com.ng/nigeria-cookie-consent',
+  downloadUrl: 'https://www.npmjs.com/package/@tantainnovative/ndpr-toolkit',
+  license: 'https://opensource.org/licenses/MIT',
+  offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  keywords:
+    'Nigeria cookie consent, Nigeria cookie banner, NDPA cookie consent, Section 26 consent',
+};
+
+export default function NigeriaCookieConsentLanding() {
+  return (
+    <>
+      <SiteHeader />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <main className="min-h-screen max-w-4xl mx-auto px-6 py-16">
+        <header className="mb-12">
+          <p className="text-sm font-medium uppercase tracking-wider text-muted-foreground mb-3">
+            Nigeria NDPA 2023 · MIT licensed · Open source
+          </p>
+          <h1 className="text-4xl md:text-5xl font-bold text-foreground mb-6">
+            Cookie Consent Banner for Nigerian Websites &mdash;{' '}
+            <span className="text-primary">NDPA 2023 Compliant</span>
+          </h1>
+          <p className="text-xl text-muted-foreground leading-relaxed">
+            A drop-in React cookie consent banner built for the Nigeria Data
+            Protection Act 2023. Granular categories, audit log, easy
+            withdrawal, version-bump re-prompt, and pluggable storage adapters
+            for any backend. Free and open source.
+          </p>
+          <div className="flex flex-wrap gap-3 mt-8">
+            <Link
+              href="/docs/components/consent-management"
+              className="inline-flex items-center gap-2 px-5 py-3 rounded-lg bg-primary text-primary-foreground font-medium hover:opacity-90"
+            >
+              Read the docs →
+            </Link>
+            <Link
+              href="/ndpr-demos/consent"
+              className="inline-flex items-center gap-2 px-5 py-3 rounded-lg border border-border text-foreground font-medium hover:bg-card"
+            >
+              Try the live demo
+            </Link>
+          </div>
+        </header>
+
+        <section className="prose prose-invert max-w-none mb-12">
+          <h2 className="text-2xl font-bold mb-4">Why a Nigeria-specific cookie consent banner?</h2>
+          <p>
+            Generic GDPR cookie banners do not satisfy Section 26 of the Nigeria Data Protection Act 2023,
+            which requires consent to be <strong>specific, informed, freely given, and affirmative</strong>{' '}
+            &mdash; with the right to withdraw at any time made as easy as the act of giving consent.
+            The NDPR Toolkit cookie banner is built against the gazetted Act and the 2025 General
+            Application and Implementation Directive (GAID), with audit-friendly defaults Nigerian DPOs
+            can sign off on.
+          </p>
+
+          <h2 className="text-2xl font-bold mt-10 mb-4">What you get</h2>
+          <ul className="list-disc pl-6 space-y-2">
+            <li><strong>Granular consent categories</strong> &mdash; necessary (always on), analytics, marketing, advertising, functional, with human-readable purpose descriptions for every category.</li>
+            <li><strong>Section 26 withdrawal</strong> &mdash; one-click access to a consent management dialog from any page; revoke specific categories without losing necessary cookies.</li>
+            <li><strong>Version-bump re-prompt</strong> &mdash; bump the consent version when your purposes change and every prior visitor gets re-asked. No stale consent.</li>
+            <li><strong>Audit log</strong> &mdash; every accept / reject / update is recorded with timestamp and version, satisfying NDPC record-keeping requirements.</li>
+            <li><strong>Storage adapters</strong> &mdash; localStorage, sessionStorage, cookie, API, or a custom backend via <code>StorageAdapter</code>. Bring your own Prisma / Drizzle / Firestore / Supabase.</li>
+            <li><strong>RSC-safe</strong> &mdash; ships <code>&quot;use client&quot;</code> banners correctly so you can drop it into Next.js App Router without manual wrappers.</li>
+            <li><strong>Multilingual</strong> &mdash; English (Nigeria), Yorùbá, Igbo, Hausa, and Pidgin locales out of the box; custom locales via a typed <code>mergeLocale</code> helper.</li>
+            <li><strong>Accessible</strong> &mdash; WCAG 2.1 AA, full keyboard navigation, focus trap that restores focus on close, <code>prefers-reduced-motion</code> respected.</li>
+          </ul>
+
+          <h2 className="text-2xl font-bold mt-10 mb-4">30-second install</h2>
+          <pre className="bg-card border border-border rounded-lg p-4 overflow-x-auto"><code className="text-sm">{`pnpm add @tantainnovative/ndpr-toolkit`}</code></pre>
+          <p>Then drop the preset into your Next.js layout:</p>
+          <pre className="bg-card border border-border rounded-lg p-4 overflow-x-auto"><code className="text-sm">{`// app/layout.tsx
+import { NDPRConsent } from '@tantainnovative/ndpr-toolkit/presets';
+import '@tantainnovative/ndpr-toolkit/styles';
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en-NG">
+      <body>
+        {children}
+        <NDPRConsent />
+      </body>
+    </html>
+  );
+}`}</code></pre>
+          <p>
+            That&apos;s it &mdash; the banner appears on first visit, the preferences icon stays accessible site-wide,
+            and every event is persisted to <code>localStorage</code> by default. For server-side persistence
+            (recommended for fintech and health-tech), pass an <code>apiAdapter</code> and wire it to your existing
+            user model.
+          </p>
+
+          <h2 className="text-2xl font-bold mt-10 mb-4">Built for Nigerian apps</h2>
+          <p>
+            NDPR Toolkit is used by Nigerian fintech, insurtech, healthcare, and SaaS teams to satisfy the NDPC&apos;s
+            compliance notices issued to licensed banks, insurance brokers, gaming operators, and pension funds.
+            It is not legal advice &mdash; we recommend you have your DPO review the deployed consent surface
+            &mdash; but it ships every piece of the consent stack the NDPC asks about during an audit, with the
+            section references baked into the API.
+          </p>
+        </section>
+
+        <section className="border-t border-border pt-12">
+          <h2 className="text-2xl font-bold mb-6">Related</h2>
+          <ul className="space-y-3">
+            <li><Link href="/docs/components/consent-management" className="text-primary hover:underline">Consent Management — full component API reference</Link></li>
+            <li><Link href="/docs/guides/managing-consent" className="text-primary hover:underline">Guide — managing consent under NDPA 2023</Link></li>
+            <li><Link href="/ndpr-demos/consent" className="text-primary hover:underline">Interactive live demo</Link></li>
+            <li><Link href="/docs/guides/adapters" className="text-primary hover:underline">Storage adapters guide (Prisma, Drizzle, Firestore, custom)</Link></li>
+          </ul>
+        </section>
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/src/app/nigeria-privacy-policy-generator/page.tsx
+++ b/src/app/nigeria-privacy-policy-generator/page.tsx
@@ -1,0 +1,161 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { SiteHeader } from '@/components/site/SiteHeader';
+import { SiteFooter } from '@/components/site/SiteFooter';
+
+export const metadata: Metadata = {
+  title: 'Nigeria Privacy Policy Generator — NDPA 2023 Free & Open Source',
+  description:
+    'Free privacy policy generator for Nigerian websites and apps. NDPA 2023 + GAID 2025 compliant: lawful basis, data-subject rights (Section 34), retention, cross-border transfer, sensitive data, children, automated decisions, NDPC complaint route. Export to HTML, Markdown, PDF, or DOCX.',
+  keywords:
+    'Nigeria privacy policy generator, NDPA privacy policy, NDPR privacy policy template, Nigeria privacy policy template, free Nigerian privacy policy, NDPC compliant privacy policy, NDPA Section 27 privacy notice',
+  alternates: { canonical: '/nigeria-privacy-policy-generator' },
+  openGraph: {
+    title: 'Nigeria Privacy Policy Generator — NDPA 2023, Free',
+    description:
+      'Free privacy policy generator for Nigerian websites + apps. NDPA 2023 compliant. Export to HTML, Markdown, PDF, or DOCX.',
+    url: 'https://ndprtoolkit.com.ng/nigeria-privacy-policy-generator',
+    siteName: 'NDPR Toolkit',
+    images: [
+      {
+        url: '/og-image.png',
+        width: 1200,
+        height: 630,
+        alt: 'Nigeria NDPA Privacy Policy Generator',
+      },
+    ],
+    locale: 'en_NG',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Nigeria Privacy Policy Generator — Free, NDPA 2023 Compliant',
+    description:
+      'Free, open-source privacy policy generator for Nigerian apps. NDPA 2023 + GAID 2025. PDF / DOCX / HTML / Markdown export.',
+    images: ['/og-image.png'],
+  },
+};
+
+// Static, server-rendered JSON-LD — no user input — safe to inject.
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'NDPR Toolkit Privacy Policy Generator',
+  applicationCategory: 'DeveloperApplication',
+  applicationSubCategory: 'Privacy Policy Generator',
+  operatingSystem: 'Cross-platform (Browser, Node.js, Next.js, Edge)',
+  description:
+    'Free, NDPA 2023-compliant privacy policy generator for Nigerian websites and apps. Lawful basis, data-subject rights, retention, cross-border, sensitive data, children, automated decisions. HTML / Markdown / PDF / DOCX export.',
+  url: 'https://ndprtoolkit.com.ng/nigeria-privacy-policy-generator',
+  downloadUrl: 'https://www.npmjs.com/package/@tantainnovative/ndpr-toolkit',
+  license: 'https://opensource.org/licenses/MIT',
+  offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  keywords:
+    'Nigeria privacy policy generator, NDPA privacy policy, Section 27 privacy notice',
+};
+
+export default function NigeriaPrivacyPolicyGeneratorLanding() {
+  return (
+    <>
+      <SiteHeader />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <main className="min-h-screen max-w-4xl mx-auto px-6 py-16">
+        <header className="mb-12">
+          <p className="text-sm font-medium uppercase tracking-wider text-muted-foreground mb-3">
+            NDPA Section 27 · Free · No email required
+          </p>
+          <h1 className="text-4xl md:text-5xl font-bold text-foreground mb-6">
+            Nigeria Privacy Policy Generator &mdash;{' '}
+            <span className="text-primary">Free, NDPA 2023 Compliant</span>
+          </h1>
+          <p className="text-xl text-muted-foreground leading-relaxed">
+            A free, open-source privacy-policy generator built for Nigerian apps. Generates the
+            disclosures NDPA 2023 Section 27 requires &mdash; lawful basis, data-subject rights,
+            retention, cross-border transfers, sensitive data, children&apos;s data, automated
+            decisions, and the NDPC complaint route &mdash; with HTML / Markdown / PDF / DOCX
+            export. No email signup, no SaaS lock-in.
+          </p>
+          <div className="flex flex-wrap gap-3 mt-8">
+            <Link href="/docs/components/privacy-policy-generator" className="inline-flex items-center gap-2 px-5 py-3 rounded-lg bg-primary text-primary-foreground font-medium hover:opacity-90">Read the docs →</Link>
+            <Link href="/ndpr-demos/policy" className="inline-flex items-center gap-2 px-5 py-3 rounded-lg border border-border text-foreground font-medium hover:bg-card">Generate one now</Link>
+          </div>
+        </header>
+
+        <section className="prose prose-invert max-w-none mb-12">
+          <h2 className="text-2xl font-bold mb-4">What Nigerian law requires in a privacy policy</h2>
+          <p>
+            NDPA 2023 Section 27(1) lists the information a data controller must provide to data
+            subjects <strong>before</strong> collecting personal data. The privacy policy is the
+            standard surface for these disclosures:
+          </p>
+          <ul className="list-disc pl-6 space-y-1">
+            <li>Identity and contact details of the controller (and the DPO under Section 32).</li>
+            <li>Specific lawful basis for processing under Section 25(1) or Section 30(1) (for sensitive personal data).</li>
+            <li>Recipients or categories of recipients &mdash; including third-country recipients (cross-border, Section 41).</li>
+            <li>Retention period (or the criteria used to determine it).</li>
+            <li>Existence of the rights of the data subject under Part VI (Sections 34&ndash;38, plus 35 and 36).</li>
+            <li>Right to lodge a complaint with the Nigeria Data Protection Commission under Section 46(1).</li>
+            <li>Existence of automated decision-making, including profiling (Section 37), and meaningful information about the logic involved.</li>
+          </ul>
+          <p>
+            The NDPR Toolkit generator covers all of these, with section references baked into the
+            output so your DPO can verify compliance at a glance.
+          </p>
+
+          <h2 className="text-2xl font-bold mt-10 mb-4">Sections the generator includes</h2>
+          <ul className="list-disc pl-6 space-y-2">
+            <li><strong>Identity &amp; contact</strong> &mdash; organisation, address, website, privacy contact, DPO.</li>
+            <li><strong>Data we collect</strong> &mdash; itemised by category, with purpose for each.</li>
+            <li><strong>Lawful basis</strong> &mdash; consent, contract, legal obligation, vital interests, public interest, legitimate interests; cited to Section 25(1)(a)&ndash;(f).</li>
+            <li><strong>Sensitive personal data</strong> &mdash; only included when applicable; cites Section 30.</li>
+            <li><strong>Children&apos;s data</strong> &mdash; conditional section citing Section 31 and Nigeria&apos;s Child&apos;s Right Act parental-consent requirements.</li>
+            <li><strong>Data-subject rights</strong> &mdash; access (S.34(1)(a)&ndash;(b)), rectification (S.34(1)(c)), erasure (S.34(1)(d) + S.34(2)), restriction (S.34(1)(e)), withdraw consent (S.35), object (S.36), automated decisions (S.37), portability (S.38).</li>
+            <li><strong>Retention</strong> &mdash; per-category retention or the criteria used to set it.</li>
+            <li><strong>Cross-border transfer</strong> &mdash; conditional section citing Section 41 mechanisms, Section 42 adequacy, and Section 43 derogations.</li>
+            <li><strong>Automated decision-making</strong> &mdash; conditional section citing Section 37 with the right to human intervention.</li>
+            <li><strong>Complaint route</strong> &mdash; how to contact the NDPC under Section 46(1).</li>
+          </ul>
+
+          <h2 className="text-2xl font-bold mt-10 mb-4">Use it as a SaaS or self-host</h2>
+          <p>
+            The generator is a React component; you can either run it inside your own admin / DPO
+            portal, or use the headless <code>usePrivacyPolicy</code> hook to build a custom UI on
+            top of the policy engine. Either way the output is the same: a typed{' '}
+            <code>PrivacyPolicy</code> object that you can render to HTML, Markdown, PDF, or DOCX
+            via the <code>exportHTML</code> / <code>exportMarkdown</code> / <code>exportPDF</code>{' '}
+            / <code>exportDOCX</code> helpers.
+          </p>
+          <pre className="bg-card border border-border rounded-lg p-4 overflow-x-auto"><code className="text-sm">{`import { NDPRPrivacyPolicy } from '@tantainnovative/ndpr-toolkit/presets';
+
+<NDPRPrivacyPolicy
+  organization={{ name: 'Acme NG', address: 'Lagos, Nigeria', dpoEmail: 'dpo@acme.ng' }}
+  features={{ hasChildrenData: true, hasCrossBorderTransfer: true }}
+/>;`}</code></pre>
+
+          <h2 className="text-2xl font-bold mt-10 mb-4">Not legal advice</h2>
+          <p>
+            Every artifact this toolkit produces &mdash; including the privacy policies generated
+            here &mdash; ships with a clear &quot;not legal advice&quot; notice. NDPC&apos;s subsidiary
+            guidance evolves; your DPO or qualified Nigerian privacy counsel should sign off on the
+            final wording before publication. The generator covers the Section 27 list mechanically;
+            counsel makes the judgement calls.
+          </p>
+        </section>
+
+        <section className="border-t border-border pt-12">
+          <h2 className="text-2xl font-bold mb-6">Related</h2>
+          <ul className="space-y-3">
+            <li><Link href="/docs/components/privacy-policy-generator" className="text-primary hover:underline">Privacy Policy Generator — full API reference</Link></li>
+            <li><Link href="/ndpr-demos/policy" className="text-primary hover:underline">Generate a policy now (live demo)</Link></li>
+            <li><Link href="/docs/guides/lawful-basis" className="text-primary hover:underline">Guide — choosing a lawful basis under Section 25</Link></li>
+            <li><Link href="/docs/components/data-subject-rights" className="text-primary hover:underline">Data-subject rights portal (Section 34)</Link></li>
+          </ul>
+        </section>
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -24,6 +24,26 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 1.0,
     },
 
+    // Long-tail SEO landing pages (Nigeria-specific queries)
+    {
+      url: `${baseUrl}/nigeria-cookie-consent`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.85,
+    },
+    {
+      url: `${baseUrl}/ndpa-dpia-tool`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.85,
+    },
+    {
+      url: `${baseUrl}/nigeria-privacy-policy-generator`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.85,
+    },
+
     // Docs index
     {
       url: `${baseUrl}/docs`,


### PR DESCRIPTION
## Summary

Docs-site SEO patch from the original 20-agent audit's discoverability findings. No library code changes (the npm package is unaffected).

### What changed

- **"Nigeria" disambiguation** across all titles + descriptions. The audit's core insight was that the homepage title "NDPA Toolkit — NDPA 2023 Compliance Infrastructure for React" loses to Nebraska's NDPA in Google. Every layout title now leads with "Nigeria" or "Nigeria NDPA".
- **Canonical URLs** (`alternates.canonical`) on root, /docs, /docs/components, /ndpr-demos. Consolidates ranking signals + prevents duplicate-content penalties.
- **Site-wide JSON-LD** added in root layout:
  - `SoftwareApplication` schema (rich snippet: app category, MIT license, free, OS support, version 3.5.5)
  - `Organization` schema (links GitHub, npm, LinkedIn for Tanta Innovatives)
- **`html lang`** changed from `en` → `en-NG` and `og:locale` from `en_US` → `en_NG`. Sends a Nigeria-geo signal to Google.
- **Three long-tail SEO landing pages**, each ~600 words with full meta + JSON-LD + CTA to docs/demo:
  - **`/nigeria-cookie-consent`** — targets "cookie consent Nigeria", "NDPA cookie banner", etc. (audit identified as winnable; currently dominated by Termly/TermsFeed/CookieHub.)
  - **`/ndpa-dpia-tool`** — targets "NDPR DPIA tool", "NDPA Section 28 DPIA". (Audit said low-competition + intent-aligned.)
  - **`/nigeria-privacy-policy-generator`** — targets "nigeria privacy policy generator", "NDPA privacy policy". (Audit said winnable; SmartKeys/NDPC PDFs currently rank.)
- All three pages added to sitemap with priority 0.85.

### Done outside this PR (via gh api)

- Repo description updated to mention "Nigeria Data Protection Act (NDPA) 2023" prominently
- Repo topics replaced with the 20 most-searched relevant terms (nigeria, ndpa, ndpa-2023, ndpr, ndpc, nigeria-compliance, gdpr-nigeria, cookie-consent, dpia, dsr, breach-notification, etc.)

### Test plan

- [ ] Pull and `pnpm install && pnpm dev`; visit each new page on localhost:3000:
  - http://localhost:3000/nigeria-cookie-consent
  - http://localhost:3000/ndpa-dpia-tool
  - http://localhost:3000/nigeria-privacy-policy-generator
- [ ] View page source on the homepage; confirm both JSON-LD blocks appear in `<head>`
- [ ] After merge + deploy, run https://search.google.com/test/rich-results on the homepage URL — should validate `SoftwareApplication` + `Organization` schemas
- [ ] After merge + deploy, run https://search.google.com/test/rich-results on each long-tail landing page
- [ ] In ~2-4 weeks, check ranking improvements on the queries the audit flagged as winnable

### Note

This patch is docs-only — there's no `3.5.6` package release for `@tantainnovative/ndpr-toolkit` since the library itself didn't change. The version bump is implicit when the next library patch lands.