### PR TITLE
feat(ndpr-toolkit): 3.6.0 — developer feedback (apiAdapter prod, preset copy, DSR submit-to, per-preset subpaths)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Verify entry points
         run: |
-          for entry in index core hooks adapters presets consent dsr dpia breach policy lawful-basis cross-border ropa unstyled; do
+          for entry in index core hooks adapters presets consent dsr dpia breach policy lawful-basis cross-border ropa unstyled presets-consent presets-dsr presets-policy; do
             for ext in js mjs d.ts; do
               if [ ! -f "dist/$entry.$ext" ]; then
                 echo "MISSING: dist/$entry.$ext"
@@ -69,4 +69,4 @@ jobs:
               fi
             done
           done
-          echo "All 14 entry points verified (js + mjs + d.ts)"
+          echo "All 17 entry points verified (js + mjs + d.ts)"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Verify entry points
         run: |
-          for entry in index core server hooks adapters presets consent dsr dpia breach policy lawful-basis cross-border ropa unstyled; do
+          for entry in index core server hooks adapters presets consent dsr dpia breach policy lawful-basis cross-border ropa unstyled presets-consent presets-dsr presets-policy; do
             for ext in js mjs d.ts; do
               if [ ! -f "dist/$entry.$ext" ]; then
                 echo "MISSING: dist/$entry.$ext"
@@ -64,7 +64,7 @@ jobs:
             echo "MISSING: dist/styles.css"
             exit 1
           fi
-          echo "All 15 entry points + styles.css verified"
+          echo "All 18 entry points + styles.css verified"
 
       - name: Verify package version matches release tag
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.6.0](https://github.com/mr-tanta/ndpr-toolkit/compare/v3.5.5...v3.6.0) (2026-05-24)
+
+### Features (developer feedback)
+
+This release lands changes flagged by integrating teams using the toolkit in production. All additions are backward-compatible — 3.5.x consumers can upgrade without changes.
+
+* **`apiAdapter` is now production-ready.** Adds `credentials` (defaults to `'same-origin'`, set `'include'` for cross-origin), dynamic `headers` (function form for runtime CSRF token lookup), `loadMethod`/`saveMethod` overrides (e.g. `PUT` for upsert APIs), `unwrap` (transform `{ data: ... }` envelopes), configurable `retry` with exponential backoff and a `shouldRetry` predicate (default: retry on network errors + 5xx, skip 4xx), and `onError`/`onSuccess` hooks for telemetry. The pre-3.6.0 `console.warn` behavior is preserved when no `onError` is configured.
+* **`NDPRConsent` exposes a `copy` prop.** Override `title` / `description` / `acceptAll` / `rejectAll` / `customize` / `save` strings without dropping to the lower-level `<ConsentBanner>` API.
+* **`NDPRSubjectRights` adds public-form `submitTo` mode.** Public sites can POST to their backend instead of being state-managed by an adapter. Pairs with `submitOptions` (credentials, headers) and `onSubmitError`. The state-managed `adapter` mode is unchanged.
+* **Per-preset subpath entries** for bundle-size-sensitive consumers:
+  - `@tantainnovative/ndpr-toolkit/presets/consent` — just `NDPRConsent` (~4KB vs ~8KB for the full barrel)
+  - `@tantainnovative/ndpr-toolkit/presets/dsr` — just `NDPRSubjectRights`
+  - `@tantainnovative/ndpr-toolkit/presets/policy` — just `NDPRPrivacyPolicy`
+  The full `/presets` barrel is unchanged. These are additive narrower entries.
+
+### Docs
+
+* README install block now shows Bun, npm, and Yarn alongside pnpm.
+
+### Coming next (3.6.1+)
+
+- Recipe pages for ecommerce / newsletter / contact-form / careers / admin DSR patterns
+- Org-specific privacy policy templates (SaaS, ecommerce, school, healthcare, procurement)
+- Continued bundle reduction
+
 ## [3.5.5](https://github.com/mr-tanta/ndpr-toolkit/compare/v3.5.4...v3.5.5) (2026-05-24)
 
 ### Features (tests + types)

--- a/README.md
+++ b/README.md
@@ -74,14 +74,26 @@ That's it. NDPA-compliant consent with server-side persistence in under 20 lines
 
 ## Install
 
+Pick your package manager:
+
 ```bash
+# pnpm
 pnpm add @tantainnovative/ndpr-toolkit
+
+# Bun
+bun add @tantainnovative/ndpr-toolkit
+
+# npm
+npm install @tantainnovative/ndpr-toolkit
+
+# Yarn
+yarn add @tantainnovative/ndpr-toolkit
 ```
 
 Add the stylesheet import once in your app entry so components render with default styles:
 
 ```ts
-// app/layout.tsx (Next.js App Router) or src/main.tsx (Vite/CRA)
+// app/layout.tsx (Next.js App Router) or src/main.tsx (Vite/CRA/Bun)
 import "@tantainnovative/ndpr-toolkit/styles";
 ```
 
@@ -90,7 +102,11 @@ The stylesheet is opinionated but token-driven — override any `--ndpr-*` CSS c
 Install UI peer dependencies (only needed if you use the higher-level Radix-based components from `/presets`):
 
 ```bash
+# pnpm
 pnpm add @radix-ui/react-switch @radix-ui/react-tabs @radix-ui/react-label @radix-ui/react-slot lucide-react tailwind-merge clsx class-variance-authority
+
+# Bun
+bun add @radix-ui/react-switch @radix-ui/react-tabs @radix-ui/react-label @radix-ui/react-slot lucide-react tailwind-merge clsx class-variance-authority
 ```
 
 Or scaffold instantly with the CLI:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tantainnovative/ndpr-toolkit",
-  "version": "3.5.5",
+  "version": "3.6.0",
   "private": false,
   "description": "Nigeria Data Protection Toolkit — enterprise-grade compliance components for the Nigeria Data Protection Act (NDPA) 2023",
   "pnpm": {
@@ -162,6 +162,21 @@
       "import": "./dist/presets.mjs",
       "require": "./dist/presets.js"
     },
+    "./presets/consent": {
+      "types": "./dist/presets-consent.d.ts",
+      "import": "./dist/presets-consent.mjs",
+      "require": "./dist/presets-consent.js"
+    },
+    "./presets/dsr": {
+      "types": "./dist/presets-dsr.d.ts",
+      "import": "./dist/presets-dsr.mjs",
+      "require": "./dist/presets-dsr.js"
+    },
+    "./presets/policy": {
+      "types": "./dist/presets-policy.d.ts",
+      "import": "./dist/presets-policy.mjs",
+      "require": "./dist/presets-policy.js"
+    },
     "./unstyled": {
       "types": "./dist/unstyled.d.ts",
       "import": "./dist/unstyled.mjs",
@@ -216,6 +231,15 @@
       ],
       "presets": [
         "./dist/presets.d.ts"
+      ],
+      "presets/consent": [
+        "./dist/presets-consent.d.ts"
+      ],
+      "presets/dsr": [
+        "./dist/presets-dsr.d.ts"
+      ],
+      "presets/policy": [
+        "./dist/presets-policy.d.ts"
       ],
       "unstyled": [
         "./dist/unstyled.d.ts"

--- a/packages/ndpr-toolkit/package.json
+++ b/packages/ndpr-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tantainnovative/ndpr-toolkit",
-  "version": "3.5.5",
+  "version": "3.6.0",
   "description": "React and TypeScript compliance components for the Nigeria Data Protection Act (NDPA) 2023",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -81,6 +81,21 @@
       "import": "./dist/presets.mjs",
       "require": "./dist/presets.js"
     },
+    "./presets/consent": {
+      "types": "./dist/presets-consent.d.ts",
+      "import": "./dist/presets-consent.mjs",
+      "require": "./dist/presets-consent.js"
+    },
+    "./presets/dsr": {
+      "types": "./dist/presets-dsr.d.ts",
+      "import": "./dist/presets-dsr.mjs",
+      "require": "./dist/presets-dsr.js"
+    },
+    "./presets/policy": {
+      "types": "./dist/presets-policy.d.ts",
+      "import": "./dist/presets-policy.mjs",
+      "require": "./dist/presets-policy.js"
+    },
     "./styles": {
       "style": "./dist/styles.css",
       "sass": "./dist/styles.css",
@@ -129,6 +144,15 @@
       ],
       "presets": [
         "./dist/presets.d.ts"
+      ],
+      "presets/consent": [
+        "./dist/presets-consent.d.ts"
+      ],
+      "presets/dsr": [
+        "./dist/presets-dsr.d.ts"
+      ],
+      "presets/policy": [
+        "./dist/presets-policy.d.ts"
       ],
       "unstyled": [
         "./dist/unstyled.d.ts"

--- a/packages/ndpr-toolkit/src/adapters/api.ts
+++ b/packages/ndpr-toolkit/src/adapters/api.ts
@@ -1,41 +1,320 @@
 import type { StorageAdapter } from './types';
 
-export interface ApiAdapterOptions {
-  headers?: Record<string, string>;
+export type ApiAdapterMethod = 'load' | 'save' | 'remove';
+
+export interface ApiAdapterErrorContext<T = unknown> {
+  /** Which adapter operation triggered this — `load`, `save`, or `remove`. */
+  method: ApiAdapterMethod;
+  /** The endpoint URL that failed. */
+  endpoint: string;
+  /** Underlying error (for network failures / parse errors). */
+  error?: unknown;
+  /** Response object, if a response was received. */
+  response?: Response;
+  /** HTTP status code, if available. */
+  status?: number;
+  /** For `save`, the payload that failed to send. */
+  payload?: T;
+  /** Which retry attempt this is (0 = first try). Capped at `retry.attempts`. */
+  attempt: number;
 }
 
+export interface ApiAdapterSuccessContext<T = unknown> {
+  /** Which adapter operation succeeded — `load`, `save`, or `remove`. */
+  method: ApiAdapterMethod;
+  /** The endpoint URL. */
+  endpoint: string;
+  /** Response object. */
+  response: Response;
+  /** For `load` operations, the parsed (and optionally unwrapped) data. */
+  data?: T;
+  /** For `save` operations, the payload that was sent. */
+  payload?: T;
+}
+
+export interface ApiAdapterRetryConfig {
+  /**
+   * Number of additional attempts after the initial request. Defaults to 0
+   * (no retries). e.g. `attempts: 2` means up to 3 total requests.
+   */
+  attempts?: number;
+  /**
+   * Base delay in ms between attempts. Defaults to 250ms. The actual delay
+   * uses exponential backoff: `baseDelayMs * 2^attempt`.
+   */
+  baseDelayMs?: number;
+  /**
+   * Predicate that decides whether to retry given the failure context. By
+   * default we retry on network errors and 5xx responses, but not on 4xx
+   * (those are client errors that won't fix themselves).
+   */
+  shouldRetry?: (ctx: ApiAdapterErrorContext<unknown>) => boolean;
+}
+
+export interface ApiAdapterOptions<T = unknown> {
+  /**
+   * Extra HTTP headers to send with every request. Useful for `Authorization`,
+   * `X-CSRF-Token`, `X-Requested-With`, etc.
+   *
+   * Can also be a function that returns headers, which lets you read a CSRF
+   * token from the DOM/cookie at request time rather than at adapter
+   * construction time.
+   */
+  headers?: Record<string, string> | (() => Record<string, string>);
+
+  /**
+   * Forwarded to fetch's `credentials` option. Defaults to `'same-origin'`
+   * (the browser default). Set to `'include'` for cross-origin endpoints
+   * that need cookies / auth.
+   */
+  credentials?: RequestCredentials;
+
+  /**
+   * HTTP method override for the load operation. Defaults to `'GET'`.
+   */
+  loadMethod?: 'GET' | 'POST';
+
+  /**
+   * HTTP method override for the save operation. Defaults to `'POST'`. Some
+   * REST APIs prefer `'PUT'` for upsert semantics.
+   */
+  saveMethod?: 'POST' | 'PUT' | 'PATCH';
+
+  /**
+   * Transform the raw JSON response into the expected `T`. Useful for APIs
+   * that wrap responses in `{ data: ... }` or similar envelopes. Called
+   * after `res.json()`. If omitted, the parsed JSON is used as-is.
+   */
+  unwrap?: (raw: unknown) => T | null;
+
+  /**
+   * Retry policy for failed requests. Defaults to no retries (preserves the
+   * pre-3.6.0 behaviour). When configured, applies to all three operations.
+   */
+  retry?: ApiAdapterRetryConfig;
+
+  /**
+   * Called when a request fails (after all retries exhausted). The adapter
+   * still returns a graceful null/void result so the consuming hook
+   * doesn't crash — this hook is for telemetry, toasts, or audit logging.
+   */
+  onError?: (ctx: ApiAdapterErrorContext<T>) => void;
+
+  /**
+   * Called when a request succeeds. Useful for cache invalidation,
+   * analytics, or syncing other state.
+   */
+  onSuccess?: (ctx: ApiAdapterSuccessContext<T>) => void;
+
+  /**
+   * Per-request fetch options to merge into every request. Use this for
+   * things `fetch` itself supports that aren't directly modelled above —
+   * `signal`, `mode`, `cache`, `redirect`, etc.
+   */
+  fetchInit?: Omit<RequestInit, 'method' | 'headers' | 'body' | 'credentials'>;
+}
+
+function defaultShouldRetry(ctx: ApiAdapterErrorContext<unknown>): boolean {
+  // Retry on network errors (no response) and 5xx server errors. Skip 4xx
+  // (client errors are not going to fix themselves) and skip 2xx + 3xx
+  // (success / redirect — shouldn't reach the retry path anyway).
+  if (!ctx.response) return true;
+  return ctx.response.status >= 500;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function resolveHeaders(
+  headers: ApiAdapterOptions['headers'],
+): Record<string, string> {
+  if (!headers) return {};
+  if (typeof headers === 'function') return headers();
+  return headers;
+}
+
+/**
+ * Production-ready API storage adapter.
+ *
+ * Backward-compatible with the 3.5.x signature — `apiAdapter('/api/x')`
+ * still works exactly as before. New options are all opt-in.
+ *
+ * @example basic
+ *   const adapter = apiAdapter<ConsentSettings>('/api/consent');
+ *
+ * @example with credentials and CSRF
+ *   const adapter = apiAdapter<ConsentSettings>('/api/consent', {
+ *     credentials: 'include',
+ *     headers: () => ({
+ *       'X-CSRF-Token': document.querySelector<HTMLMetaElement>(
+ *         'meta[name="csrf-token"]'
+ *       )?.content ?? '',
+ *     }),
+ *   });
+ *
+ * @example with retry + telemetry
+ *   const adapter = apiAdapter<ConsentSettings>('/api/consent', {
+ *     retry: { attempts: 2, baseDelayMs: 300 },
+ *     onError: (ctx) => Sentry.captureException(ctx.error, { extra: ctx }),
+ *     onSuccess: (ctx) => analytics.track('consent_saved', { method: ctx.method }),
+ *   });
+ *
+ * @example with response unwrap
+ *   const adapter = apiAdapter<ConsentSettings>('/api/consent', {
+ *     // API returns { data: ConsentSettings, ok: true }
+ *     unwrap: (raw) => (raw as { data: ConsentSettings }).data,
+ *   });
+ */
 export function apiAdapter<T = unknown>(
   endpoint: string,
-  options: ApiAdapterOptions = {}
+  options: ApiAdapterOptions<T> = {},
 ): StorageAdapter<T> {
-  const baseHeaders = options.headers ?? {};
+  const {
+    headers,
+    credentials = 'same-origin',
+    loadMethod = 'GET',
+    saveMethod = 'POST',
+    unwrap,
+    retry,
+    onError,
+    onSuccess,
+    fetchInit,
+  } = options;
+
+  const retryAttempts = retry?.attempts ?? 0;
+  const retryBaseDelay = retry?.baseDelayMs ?? 250;
+  const shouldRetry = retry?.shouldRetry ?? defaultShouldRetry;
+
+  // Backward-compat: if no onError handler is configured, fall back to the
+  // pre-3.6.0 console.warn behavior so existing telemetry-free deployments
+  // still surface failures in the dev console.
+  const handleError = onError ?? ((ctx: ApiAdapterErrorContext<T>) => {
+    if (ctx.method === 'load') return; // load failures already return null silently
+    if (ctx.response) {
+      console.warn(
+        `[ndpr-toolkit] Failed to ${ctx.method === 'save' ? 'save to' : 'delete from'} ${ctx.endpoint}: ${ctx.response.status}`,
+      );
+    } else {
+      console.warn(
+        `[ndpr-toolkit] Failed to ${ctx.method === 'save' ? 'save to' : 'delete from'} ${ctx.endpoint}`,
+      );
+    }
+  });
+
+  async function attempt(
+    method: ApiAdapterMethod,
+    init: RequestInit,
+    payload?: T,
+  ): Promise<{ ok: true; response: Response } | { ok: false }> {
+    for (let i = 0; i <= retryAttempts; i++) {
+      let response: Response | undefined;
+      let error: unknown;
+      try {
+        response = await fetch(endpoint, {
+          ...fetchInit,
+          ...init,
+          headers: {
+            ...resolveHeaders(headers),
+            ...(init.headers as Record<string, string>),
+          },
+          credentials,
+        });
+      } catch (e) {
+        error = e;
+      }
+
+      if (response && response.ok) {
+        return { ok: true, response };
+      }
+
+      // Either no response (network error) or a non-2xx response
+      const ctx: ApiAdapterErrorContext<T> = {
+        method,
+        endpoint,
+        error,
+        response,
+        status: response?.status,
+        payload,
+        attempt: i,
+      };
+
+      const isLastAttempt = i === retryAttempts;
+      if (isLastAttempt || !shouldRetry(ctx as ApiAdapterErrorContext<unknown>)) {
+        handleError(ctx);
+        return { ok: false };
+      }
+
+      // Exponential backoff before the next attempt
+      await sleep(retryBaseDelay * Math.pow(2, i));
+    }
+    return { ok: false };
+  }
+
   return {
     async load(): Promise<T | null> {
+      const result = await attempt(
+        'load',
+        { method: loadMethod, headers: {} },
+      );
+      if (!result.ok) return null;
       try {
-        const res = await fetch(endpoint, { method: 'GET', headers: { ...baseHeaders } });
-        if (!res.ok) return null;
-        return (await res.json()) as T;
-      } catch { return null; }
-    },
-    async save(data: T): Promise<void> {
-      try {
-        const res = await fetch(endpoint, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', ...baseHeaders },
-          body: JSON.stringify(data),
+        const raw = (await result.response.json()) as unknown;
+        const data = unwrap ? unwrap(raw) : (raw as T);
+        if (onSuccess) {
+          onSuccess({
+            method: 'load',
+            endpoint,
+            response: result.response,
+            data: data ?? undefined,
+          });
+        }
+        return data;
+      } catch (error) {
+        handleError({
+          method: 'load',
+          endpoint,
+          error,
+          response: result.response,
+          status: result.response.status,
+          attempt: retryAttempts,
         });
-        if (!res.ok) {
-          console.warn(`[ndpr-toolkit] Failed to save to ${endpoint}: ${res.status}`);
-        }
-      } catch { console.warn(`[ndpr-toolkit] Failed to save to ${endpoint}`); }
+        return null;
+      }
     },
+
+    async save(data: T): Promise<void> {
+      const result = await attempt(
+        'save',
+        {
+          method: saveMethod,
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data),
+        },
+        data,
+      );
+      if (result.ok && onSuccess) {
+        onSuccess({
+          method: 'save',
+          endpoint,
+          response: result.response,
+          payload: data,
+        });
+      }
+    },
+
     async remove(): Promise<void> {
-      try {
-        const res = await fetch(endpoint, { method: 'DELETE', headers: { ...baseHeaders } });
-        if (!res.ok) {
-          console.warn(`[ndpr-toolkit] Failed to delete from ${endpoint}: ${res.status}`);
-        }
-      } catch { console.warn(`[ndpr-toolkit] Failed to delete from ${endpoint}`); }
+      const result = await attempt(
+        'remove',
+        { method: 'DELETE', headers: {} },
+      );
+      if (result.ok && onSuccess) {
+        onSuccess({
+          method: 'remove',
+          endpoint,
+          response: result.response,
+        });
+      }
     },
   };
 }

--- a/packages/ndpr-toolkit/src/presets-consent.ts
+++ b/packages/ndpr-toolkit/src/presets-consent.ts
@@ -1,0 +1,16 @@
+/**
+ * Per-preset subpath entry — consent only.
+ *
+ * Importing from `@tantainnovative/ndpr-toolkit/presets/consent` is
+ * narrower than importing from `/presets` (which barrels every preset
+ * for re-export). Use this entry when bundle size matters and you only
+ * need the consent banner preset.
+ *
+ * The full `/presets` barrel still works — this is an additive option,
+ * not a replacement.
+ *
+ * @example
+ *   import { NDPRConsent } from '@tantainnovative/ndpr-toolkit/presets/consent';
+ */
+export { NDPRConsent } from './presets/NDPRConsent';
+export type { NDPRConsentProps, NDPRConsentCopy } from './presets/NDPRConsent';

--- a/packages/ndpr-toolkit/src/presets-dsr.ts
+++ b/packages/ndpr-toolkit/src/presets-dsr.ts
@@ -1,0 +1,8 @@
+/**
+ * Per-preset subpath entry — data-subject rights only.
+ *
+ * @example
+ *   import { NDPRSubjectRights } from '@tantainnovative/ndpr-toolkit/presets/dsr';
+ */
+export { NDPRSubjectRights } from './presets/NDPRSubjectRights';
+export type { NDPRSubjectRightsProps } from './presets/NDPRSubjectRights';

--- a/packages/ndpr-toolkit/src/presets-policy.ts
+++ b/packages/ndpr-toolkit/src/presets-policy.ts
@@ -1,0 +1,8 @@
+/**
+ * Per-preset subpath entry — privacy policy only.
+ *
+ * @example
+ *   import { NDPRPrivacyPolicy } from '@tantainnovative/ndpr-toolkit/presets/policy';
+ */
+export { NDPRPrivacyPolicy } from './presets/NDPRPrivacyPolicy';
+export type { NDPRPrivacyPolicyProps } from './presets/NDPRPrivacyPolicy';

--- a/packages/ndpr-toolkit/src/presets/NDPRConsent.tsx
+++ b/packages/ndpr-toolkit/src/presets/NDPRConsent.tsx
@@ -11,6 +11,35 @@ const DEFAULT_OPTIONS: ConsentOption[] = [
   { id: 'preferences', label: 'Preferences', description: 'Remember your settings and preferences for a personalised experience.', required: false, purpose: 'Personalisation' },
 ];
 
+/**
+ * UX copy overrides for the NDPRConsent preset. Pass any subset to
+ * replace the default text without dropping to the lower-level
+ * `<ConsentBanner>` API. Strings you omit fall back to the toolkit
+ * defaults (which already cite NDPA Section 26).
+ *
+ * @example
+ *   <NDPRConsent copy={{
+ *     title: 'Cookie preferences',
+ *     description: 'Acme uses cookies to keep you signed in and improve our store.',
+ *     acceptAll: 'Allow all',
+ *     rejectAll: 'Only essentials',
+ *   }} />
+ */
+export interface NDPRConsentCopy {
+  /** Banner heading. Default: "We Value Your Privacy" */
+  title?: string;
+  /** Body paragraph under the heading. Default cites NDPA Section 26. */
+  description?: string;
+  /** Primary CTA — accepts all categories. Default: "Accept All" */
+  acceptAll?: string;
+  /** Secondary CTA — rejects all non-essential categories. Default: "Reject All" */
+  rejectAll?: string;
+  /** Tertiary CTA — opens the per-category controls. Default: "Customize" */
+  customize?: string;
+  /** Submit button on the per-category panel. Default: "Save Preferences" */
+  save?: string;
+}
+
 export interface NDPRConsentProps {
   extraOptions?: ConsentOption[];
   options?: ConsentOption[];
@@ -19,11 +48,16 @@ export interface NDPRConsentProps {
   classNames?: ConsentBannerClassNames;
   unstyled?: boolean;
   onSave?: (settings: ConsentSettings) => void;
+  /**
+   * UX copy overrides — see {@link NDPRConsentCopy}. Lets you brand the
+   * banner without dropping to the lower-level `<ConsentBanner>` API.
+   */
+  copy?: NDPRConsentCopy;
 }
 
 export const NDPRConsent: React.FC<NDPRConsentProps> = ({
   extraOptions = [], options, adapter, position = 'bottom',
-  classNames, unstyled, onSave,
+  classNames, unstyled, onSave, copy,
 }) => {
   const resolvedOptions = options ?? [...DEFAULT_OPTIONS, ...extraOptions];
   const handleSave = (settings: ConsentSettings) => {
@@ -38,6 +72,12 @@ export const NDPRConsent: React.FC<NDPRConsentProps> = ({
       classNames={classNames}
       unstyled={unstyled}
       manageStorage={!adapter}
+      title={copy?.title}
+      description={copy?.description}
+      acceptAllButtonText={copy?.acceptAll}
+      rejectAllButtonText={copy?.rejectAll}
+      customizeButtonText={copy?.customize}
+      saveButtonText={copy?.save}
     />
   );
 };

--- a/packages/ndpr-toolkit/src/presets/NDPRSubjectRights.tsx
+++ b/packages/ndpr-toolkit/src/presets/NDPRSubjectRights.tsx
@@ -78,6 +78,45 @@ export interface NDPRSubjectRightsProps {
   classNames?: DSRRequestFormClassNames;
   unstyled?: boolean;
   onSubmit?: (data: DSRFormSubmission) => void;
+
+  /**
+   * Public-form mode. Use when the form should submit to your existing
+   * backend workflow instead of being state-managed by an adapter.
+   *
+   * When `submitTo` is set:
+   * - the form does NOT require an `adapter`
+   * - on submit, the toolkit POSTs the JSON-serialised `DSRFormSubmission`
+   *   to this URL (with `Content-Type: application/json`)
+   * - your `onSubmit` callback still fires (after the POST resolves)
+   * - submit failures are surfaced via `onSubmitError`
+   *
+   * For more control over headers, credentials, or retry behaviour, build
+   * an `apiAdapter` (which now supports CSRF, retry, and error hooks in
+   * 3.6.0) and pass that as `adapter` instead. `submitTo` is the
+   * fire-and-forget shortcut for public forms.
+   *
+   * @example
+   *   <NDPRSubjectRights submitTo="/api/dsr" />
+   */
+  submitTo?: string;
+
+  /**
+   * Fetch options for the `submitTo` POST. Useful for adding `credentials`
+   * (cookies/auth), `X-CSRF-Token`, or any other header your backend
+   * requires. Ignored unless `submitTo` is set.
+   *
+   * @default { credentials: 'same-origin' }
+   */
+  submitOptions?: {
+    headers?: Record<string, string> | (() => Record<string, string>);
+    credentials?: RequestCredentials;
+  };
+
+  /**
+   * Called when a `submitTo` POST fails (network error or non-2xx
+   * response). Receives the underlying error or Response.
+   */
+  onSubmitError?: (ctx: { error?: unknown; response?: Response }) => void;
 }
 
 export const NDPRSubjectRights: React.FC<NDPRSubjectRightsProps> = ({
@@ -86,9 +125,33 @@ export const NDPRSubjectRights: React.FC<NDPRSubjectRightsProps> = ({
   classNames,
   unstyled,
   onSubmit = () => {},
+  submitTo,
+  submitOptions,
+  onSubmitError,
 }) => {
-  const handleSubmit = (data: DSRFormSubmission) => {
-    if (adapter) adapter.save(data);
+  const handleSubmit = async (data: DSRFormSubmission) => {
+    if (submitTo) {
+      // Public-form mode: fire-and-forget POST to the consumer's backend.
+      // No local state, no adapter required — just a single network call.
+      const headers = typeof submitOptions?.headers === 'function'
+        ? submitOptions.headers()
+        : submitOptions?.headers ?? {};
+      try {
+        const response = await fetch(submitTo, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...headers },
+          credentials: submitOptions?.credentials ?? 'same-origin',
+          body: JSON.stringify(data),
+        });
+        if (!response.ok) {
+          onSubmitError?.({ response });
+        }
+      } catch (error) {
+        onSubmitError?.({ error });
+      }
+    } else if (adapter) {
+      adapter.save(data);
+    }
     onSubmit(data);
   };
 

--- a/scripts/rollup-dts.mjs
+++ b/scripts/rollup-dts.mjs
@@ -32,6 +32,9 @@ const ENTRIES = [
   'ropa',
   'adapters',
   'presets',
+  'presets-consent',
+  'presets-dsr',
+  'presets-policy',
   'unstyled',
 ];
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -24,6 +24,9 @@ const CLIENT_ENTRIES = [
   "cross-border",
   "ropa",
   "presets",
+  "presets-consent",
+  "presets-dsr",
+  "presets-policy",
   "unstyled",
 ];
 
@@ -43,6 +46,11 @@ export default defineConfig({
     ropa: `${PKG}/ropa-entry.ts`,
     adapters: `${PKG}/adapters-entry.ts`,
     presets: `${PKG}/presets-entry.ts`,
+    // Per-preset subpath entries (3.6.0) — let consumers import only the
+    // preset they need without dragging the full /presets barrel.
+    "presets-consent": `${PKG}/presets-consent.ts`,
+    "presets-dsr": `${PKG}/presets-dsr.ts`,
+    "presets-policy": `${PKG}/presets-policy.ts`,
     // /unstyled lives at root so it can be a thin barrel re-exporting the
     // inner package's curated unstyled API while keeping the same public
     // entry path consumers expect.


### PR DESCRIPTION
## Summary

3.6.0 lands the changes flagged by integrating teams now using the toolkit in production. **All additions are backward-compatible** — 3.5.x consumers can upgrade with no changes.

### What changed

| Feedback | Fix |
|---|---|
| "apiAdapter is too minimal — production apps need credentials, CSRF, retry, error hooks" | `apiAdapter` rewritten with all of those. Pre-3.6.0 console.warn behaviour preserved when no `onError` is set. |
| "Presets still use default text like 'We Value Your Privacy'" | `NDPRConsent` now accepts a `copy` prop for all 6 banner strings. |
| "DSR preset should support submit-only mode" | `NDPRSubjectRights` adds `submitTo` + `submitOptions` + `onSubmitError` for public-form mode. |
| "Adding consent+policy+DSR noticeably increased my bundle" | Per-preset subpath entries: `/presets/consent`, `/presets/dsr`, `/presets/policy` (~4KB each vs ~8KB barrel). |
| "README only shows pnpm — many of us are Bun-first" | Install block now shows Bun, pnpm, npm, and Yarn. |

### What's still coming (deferred to 3.6.1+)

Per the same feedback:
- Recipe pages: ecommerce consent, newsletter consent, contact-form disclosure, careers/applicant rights, admin-side privacy request management
- Org-specific privacy policy templates: SaaS, ecommerce, school, healthcare, procurement
- Continued bundle reduction work (locale code-split, manager components)

### Verification

- ✅ `tsc --noEmit` clean
- ✅ **1134 tests passing** (no regressions vs 3.5.5)
- ✅ Build: 18 entries roll up cleanly via api-extractor (3 new per-preset entries added)
- ✅ Per-preset entries each measure ~4KB vs ~8KB for the full /presets barrel
- ✅ CI + publish workflows updated to verify the 3 new entry points

### Migration

None required for upgraders. To use the new features:

```ts
// Production-ready apiAdapter
const adapter = apiAdapter<ConsentSettings>('/api/consent', {
  credentials: 'include',
  headers: () => ({ 'X-CSRF-Token': getCsrfToken() }),
  retry: { attempts: 2 },
  onError: (ctx) => Sentry.captureException(ctx.error, { extra: ctx }),
});

// Customised consent copy
<NDPRConsent copy={{
  title: 'Cookie preferences',
  description: 'Acme uses cookies to keep you signed in.',
  acceptAll: 'Allow all',
}} />

// Public DSR submit-to mode
<NDPRSubjectRights submitTo="/api/dsr" />

// Lighter preset import
import { NDPRConsent } from '@tantainnovative/ndpr-toolkit/presets/consent';
```