### PR TITLE
feat(docs): Phase C — hosted NDPA Audit Score lead-magnet at /score

### DIFF
--- a/package.json
+++ b/package.json
@@ -317,6 +317,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
+    "@phosphor-icons/react": "^2.1.7",
     "@tailwindcss/postcss": "^4.1.13",
     "@tantainnovative/ndpr-toolkit": "^3.7.0",
     "@testing-library/dom": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -318,7 +318,7 @@
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@tailwindcss/postcss": "^4.1.13",
-    "@tantainnovative/ndpr-toolkit": "3.3.0",
+    "@tantainnovative/ndpr-toolkit": "^3.7.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/src/app/HomePageClient.tsx
+++ b/src/app/HomePageClient.tsx
@@ -460,14 +460,17 @@ export function HomePageClient() {
                   gap: 'var(--space-3)',
                   marginTop: 'var(--space-8)',
                 }}>
-                  <SiteButton variant="primary" size="lg" href="/docs">
-                    Get Started
+                  <SiteButton variant="primary" size="lg" href="/score">
+                    Free NDPA Audit · 5 min
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" style={{ marginLeft: '4px' }}>
                       <path d="M5 12h14" /><path d="m12 5 7 7-7 7" />
                     </svg>
                   </SiteButton>
+                  <SiteButton variant="secondary" size="lg" href="/docs">
+                    Get Started
+                  </SiteButton>
                   <SiteButton
-                    variant="secondary"
+                    variant="ghost"
                     size="lg"
                     href="https://github.com/mr-tanta/ndpr-toolkit"
                     icon={

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -121,3 +121,40 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* ──────────────────────────────────────────────────────────────────────
+ * Print styles — strip site chrome so the /score PDF export looks clean.
+ * Targets the SiteHeader / SiteFooter and the right-rail sticky card so a
+ * single-flow document prints with just the questionnaire + score +
+ * recommendations.
+ * ────────────────────────────────────────────────────────────────────── */
+@media print {
+  header[data-site-header],
+  footer[data-site-footer],
+  nav[aria-label="Main navigation"],
+  [data-print-hide="true"] {
+    display: none !important;
+  }
+  body {
+    background: white !important;
+    color: black !important;
+  }
+  main {
+    max-width: none !important;
+    padding: 0 !important;
+  }
+  /* The right-rail score panel is sticky on screen; in print, let it flow
+     naturally above the recommendations. */
+  aside.lg\:sticky {
+    position: static !important;
+    margin-bottom: 1.5rem;
+  }
+  /* Avoid awkward page breaks mid-card */
+  section, article, aside {
+    break-inside: avoid;
+  }
+  a {
+    text-decoration: none !important;
+    color: inherit !important;
+  }
+}

--- a/src/app/ndpa-dpia-tool/page.tsx
+++ b/src/app/ndpa-dpia-tool/page.tsx
@@ -141,6 +141,22 @@ export default function DPIAPage() {
           </p>
         </section>
 
+        <section className="border-t border-border pt-10 pb-2 mb-10">
+          <div className="rounded-lg border border-primary/30 bg-primary/5 p-6">
+            <h2 className="text-xl font-bold mb-2">Want to know your overall NDPA risk?</h2>
+            <p className="text-base text-muted-foreground mb-4">
+              The DPIA tool covers Section 28. The free 5-minute audit scores your whole compliance
+              posture across all 8 NDPA modules with prioritised fixes.
+            </p>
+            <Link
+              href="/score"
+              className="inline-flex items-center gap-2 px-5 py-3 rounded-lg bg-primary text-primary-foreground font-medium hover:opacity-90"
+            >
+              Run the free NDPA audit →
+            </Link>
+          </div>
+        </section>
+
         <section className="border-t border-border pt-12">
           <h2 className="text-2xl font-bold mb-6">Related</h2>
           <ul className="space-y-3">

--- a/src/app/nigeria-cookie-consent/page.tsx
+++ b/src/app/nigeria-cookie-consent/page.tsx
@@ -150,6 +150,22 @@ export default function RootLayout({ children }) {
           </p>
         </section>
 
+        <section className="border-t border-border pt-10 pb-2 mb-10">
+          <div className="rounded-lg border border-primary/30 bg-primary/5 p-6">
+            <h2 className="text-xl font-bold mb-2">Not sure if your consent flow already passes?</h2>
+            <p className="text-base text-muted-foreground mb-4">
+              Take the free 5-minute NDPA audit. It scores your consent banner, DSR portal, breach
+              process, and 5 other modules against the gazetted Act and gives you prioritised fixes.
+            </p>
+            <Link
+              href="/score"
+              className="inline-flex items-center gap-2 px-5 py-3 rounded-lg bg-primary text-primary-foreground font-medium hover:opacity-90"
+            >
+              Run the free NDPA audit →
+            </Link>
+          </div>
+        </section>
+
         <section className="border-t border-border pt-12">
           <h2 className="text-2xl font-bold mb-6">Related</h2>
           <ul className="space-y-3">

--- a/src/app/nigeria-privacy-policy-generator/page.tsx
+++ b/src/app/nigeria-privacy-policy-generator/page.tsx
@@ -145,6 +145,22 @@ export default function NigeriaPrivacyPolicyGeneratorLanding() {
           </p>
         </section>
 
+        <section className="border-t border-border pt-10 pb-2 mb-10">
+          <div className="rounded-lg border border-primary/30 bg-primary/5 p-6">
+            <h2 className="text-xl font-bold mb-2">Not sure what to put in the policy?</h2>
+            <p className="text-base text-muted-foreground mb-4">
+              The free 5-minute audit walks you through every Section 27(1) disclosure — and 7 other
+              compliance areas — and tells you exactly what to add.
+            </p>
+            <Link
+              href="/score"
+              className="inline-flex items-center gap-2 px-5 py-3 rounded-lg bg-primary text-primary-foreground font-medium hover:opacity-90"
+            >
+              Run the free NDPA audit →
+            </Link>
+          </div>
+        </section>
+
         <section className="border-t border-border pt-12">
           <h2 className="text-2xl font-bold mb-6">Related</h2>
           <ul className="space-y-3">

--- a/src/app/score/components/AuditScore.tsx
+++ b/src/app/score/components/AuditScore.tsx
@@ -1,0 +1,536 @@
+'use client';
+
+import { useState, useMemo, useCallback } from 'react';
+import Link from 'next/link';
+import {
+  getComplianceScore,
+  type ComplianceInput,
+  type ComplianceReport,
+  type RecommendationPriority,
+} from '@tantainnovative/ndpr-toolkit/server';
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Default state — every flag starts at false ("haven't done it") so the
+ * initial score is honestly bad. Users adjust each section as they walk
+ * through the questionnaire. Dates default to today (treats existing
+ * policy/RoPA as fresh; if user hasn't reviewed at all they should leave
+ * the date far in the past — we surface a hint to that effect).
+ * ────────────────────────────────────────────────────────────────────────── */
+
+const today = new Date().toISOString().slice(0, 10);
+
+const DEFAULT_INPUT: ComplianceInput = {
+  consent: {
+    hasConsentMechanism: false,
+    hasPurposeSpecification: false,
+    hasWithdrawalMechanism: false,
+    hasMinorProtection: false,
+    consentRecordsRetained: false,
+  },
+  dsr: {
+    hasRequestMechanism: false,
+    supportsAccess: false,
+    supportsRectification: false,
+    supportsErasure: false,
+    supportsPortability: false,
+    supportsObjection: false,
+    responseTimelineDays: 30,
+  },
+  dpia: {
+    conductedForHighRisk: false,
+    documentedRisks: false,
+    mitigationMeasures: false,
+  },
+  breach: {
+    hasNotificationProcess: false,
+    notifiesWithin72Hours: false,
+    hasRiskAssessment: false,
+    hasRecordKeeping: false,
+  },
+  policy: {
+    hasPrivacyPolicy: false,
+    isPubliclyAccessible: false,
+    lastUpdated: today,
+    coversAllSections: false,
+  },
+  lawfulBasis: {
+    documentedForAllProcessing: false,
+    hasLegitimateInterestAssessment: false,
+  },
+  crossBorder: {
+    hasTransferMechanisms: false,
+    adequacyAssessed: false,
+    ndpcApprovalObtained: false,
+  },
+  ropa: {
+    maintained: false,
+    includesAllProcessing: false,
+    lastReviewed: today,
+  },
+};
+
+/* Per-flag prompt labels — what the user actually reads. */
+type SectionConfig = {
+  id: keyof ComplianceInput;
+  title: string;
+  ndpa: string;
+  questions: ReadonlyArray<{
+    key: string;
+    label: string;
+    hint?: string;
+  }>;
+};
+
+const SECTIONS: SectionConfig[] = [
+  {
+    id: 'consent',
+    title: 'Consent',
+    ndpa: 'NDPA Section 26',
+    questions: [
+      { key: 'hasConsentMechanism', label: 'We have a cookie / consent banner on every public-facing page.' },
+      { key: 'hasPurposeSpecification', label: 'Each consent option lists a specific, named purpose.' },
+      { key: 'hasWithdrawalMechanism', label: 'Users can withdraw consent as easily as they gave it (Section 26).' },
+      { key: 'hasMinorProtection', label: 'Where applicable, we collect parental consent for minors (Section 31).' },
+      { key: 'consentRecordsRetained', label: 'We keep an audit log of every consent decision (who, when, what, version).' },
+    ],
+  },
+  {
+    id: 'dsr',
+    title: 'Data Subject Rights',
+    ndpa: 'NDPA Part VI (Sections 34–38)',
+    questions: [
+      { key: 'hasRequestMechanism', label: 'We have a published DSR submission channel (form or email).' },
+      { key: 'supportsAccess', label: 'We can fulfil access requests (Section 34(1)(a)).' },
+      { key: 'supportsRectification', label: 'We can fulfil rectification requests (Section 34(1)(c)).' },
+      { key: 'supportsErasure', label: 'We can fulfil erasure requests (Section 34(1)(d)).' },
+      { key: 'supportsPortability', label: 'We can fulfil portability requests (Section 38).' },
+      { key: 'supportsObjection', label: 'We can fulfil objection requests (Section 36).' },
+    ],
+  },
+  {
+    id: 'dpia',
+    title: 'DPIA',
+    ndpa: 'NDPA Section 28',
+    questions: [
+      { key: 'conductedForHighRisk', label: 'We complete a DPIA before any high-risk processing (Section 28(1)).' },
+      { key: 'documentedRisks', label: 'Each DPIA documents identified risks to data subjects.' },
+      { key: 'mitigationMeasures', label: 'Each DPIA includes mitigation measures and residual-risk acceptance.' },
+    ],
+  },
+  {
+    id: 'breach',
+    title: 'Breach Notification',
+    ndpa: 'NDPA Section 40',
+    questions: [
+      { key: 'hasNotificationProcess', label: 'We have a documented breach-notification process.' },
+      { key: 'notifiesWithin72Hours', label: 'Our process can notify NDPC within 72 hours of discovery (Section 40(2)).' },
+      { key: 'hasRiskAssessment', label: 'Every breach triggers a risk assessment to determine notification need.' },
+      { key: 'hasRecordKeeping', label: 'We maintain a breach register with all incidents and actions.' },
+    ],
+  },
+  {
+    id: 'policy',
+    title: 'Privacy Policy',
+    ndpa: 'NDPA Section 27',
+    questions: [
+      { key: 'hasPrivacyPolicy', label: 'We publish a privacy policy.' },
+      { key: 'isPubliclyAccessible', label: 'The privacy policy is reachable from every page (usually footer).' },
+      { key: 'coversAllSections', label: 'The policy covers every Section 27(1) disclosure (lawful basis, retention, rights, NDPC complaint route).' },
+    ],
+  },
+  {
+    id: 'lawfulBasis',
+    title: 'Lawful Basis',
+    ndpa: 'NDPA Section 25',
+    questions: [
+      { key: 'documentedForAllProcessing', label: 'We have documented a lawful basis for every processing activity.' },
+      { key: 'hasLegitimateInterestAssessment', label: 'Where we rely on legitimate interest, we have a written LIA.' },
+    ],
+  },
+  {
+    id: 'crossBorder',
+    title: 'Cross-Border Transfer',
+    ndpa: 'NDPA Sections 41–43',
+    questions: [
+      { key: 'hasTransferMechanisms', label: 'We have an appropriate transfer mechanism for every cross-border data flow.' },
+      { key: 'adequacyAssessed', label: 'We have assessed the adequacy of each destination country (Section 42).' },
+      { key: 'ndpcApprovalObtained', label: 'Where required, we have obtained NDPC approval (BCRs, codes of conduct, certifications).' },
+    ],
+  },
+  {
+    id: 'ropa',
+    title: 'Record of Processing Activities',
+    ndpa: 'NDPA Section 29',
+    questions: [
+      { key: 'maintained', label: 'We maintain a Record of Processing Activities (RoPA).' },
+      { key: 'includesAllProcessing', label: 'The RoPA covers every processing activity across the organisation.' },
+    ],
+  },
+];
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Score UI
+ * ────────────────────────────────────────────────────────────────────────── */
+
+function ratingColor(rating: ComplianceReport['rating']): string {
+  switch (rating) {
+    case 'excellent': return 'text-emerald-500';
+    case 'good': return 'text-blue-500';
+    case 'needs-work': return 'text-orange-500';
+    case 'critical': return 'text-red-500';
+    default: return 'text-foreground';
+  }
+}
+
+/** Compute a rating bucket for an individual module score. The library only
+ * exposes an overall rating, but per-module we want the same colour scale. */
+function moduleRating(score: number): ComplianceReport['rating'] {
+  if (score >= 90) return 'excellent';
+  if (score >= 70) return 'good';
+  if (score >= 50) return 'needs-work';
+  return 'critical';
+}
+
+function ratingSummary(rating: ComplianceReport['rating'], score: number): string {
+  switch (rating) {
+    case 'excellent':
+      return `Strong NDPA posture at ${score}/100. Verify with your DPO and keep RoPA + policy reviews current.`;
+    case 'good':
+      return `Solid foundations at ${score}/100. A few high-priority gaps to close — see the recommendations below.`;
+    case 'needs-work':
+      return `Material gaps at ${score}/100. Multiple critical items below — prioritise the red items first.`;
+    case 'critical':
+      return `Significant exposure at ${score}/100. Engage your DPO immediately and start with the critical items.`;
+    default:
+      return `${score}/100`;
+  }
+}
+
+function priorityColor(p: RecommendationPriority): string {
+  switch (p) {
+    case 'critical': return 'border-red-300 bg-red-50 dark:border-red-900 dark:bg-red-950';
+    case 'high': return 'border-orange-300 bg-orange-50 dark:border-orange-900 dark:bg-orange-950';
+    case 'medium': return 'border-amber-300 bg-amber-50 dark:border-amber-900 dark:bg-amber-950';
+    case 'low': return 'border-blue-300 bg-blue-50 dark:border-blue-900 dark:bg-blue-950';
+    default: return 'border-border bg-card';
+  }
+}
+
+export function AuditScore() {
+  const [input, setInput] = useState<ComplianceInput>(DEFAULT_INPUT);
+  const [submitted, setSubmitted] = useState(false);
+
+  const report = useMemo(() => getComplianceScore(input), [input]);
+
+  const toggleFlag = useCallback(
+    (sectionId: keyof ComplianceInput, key: string, checked: boolean) => {
+      setInput((prev) => ({
+        ...prev,
+        [sectionId]: {
+          ...(prev[sectionId] as Record<string, unknown>),
+          [key]: checked,
+        },
+      }));
+    },
+    [],
+  );
+
+  const setPolicyDate = useCallback((iso: string) => {
+    setInput((prev) => ({ ...prev, policy: { ...prev.policy, lastUpdated: iso } }));
+  }, []);
+
+  const setRopaDate = useCallback((iso: string) => {
+    setInput((prev) => ({ ...prev, ropa: { ...prev.ropa, lastReviewed: iso } }));
+  }, []);
+
+  const setResponseDays = useCallback((days: number) => {
+    setInput((prev) => ({
+      ...prev,
+      dsr: { ...prev.dsr, responseTimelineDays: Math.max(0, Math.min(365, days)) },
+    }));
+  }, []);
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-8">
+      {/* ── Left column: questionnaire ───────────────────────────────────── */}
+      <div className="space-y-6">
+        {SECTIONS.map((section) => {
+          const sectionValues = input[section.id] as Record<string, unknown>;
+          return (
+            <section key={section.id} className="rounded-lg border border-border p-6 bg-card">
+              <header className="mb-4">
+                <h2 className="text-xl font-semibold text-foreground">{section.title}</h2>
+                <p className="text-xs uppercase tracking-wider text-muted-foreground">{section.ndpa}</p>
+              </header>
+              <div className="space-y-3">
+                {section.questions.map((q) => (
+                  <label key={q.key} className="flex items-start gap-3 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={Boolean(sectionValues[q.key])}
+                      onChange={(e) => toggleFlag(section.id, q.key, e.target.checked)}
+                      className="mt-1 h-4 w-4 rounded border-gray-400 text-primary focus:ring-primary"
+                    />
+                    <span className="text-sm text-foreground">{q.label}</span>
+                  </label>
+                ))}
+
+                {/* Section-specific extras */}
+                {section.id === 'dsr' && (
+                  <label className="flex items-center gap-3 mt-3">
+                    <span className="text-sm text-foreground">Typical response time</span>
+                    <input
+                      type="number"
+                      min={1}
+                      max={120}
+                      value={input.dsr.responseTimelineDays}
+                      onChange={(e) => setResponseDays(Number(e.target.value))}
+                      className="w-20 rounded border border-border bg-background px-2 py-1 text-sm"
+                    />
+                    <span className="text-sm text-muted-foreground">days (NDPC guidance: 30)</span>
+                  </label>
+                )}
+                {section.id === 'policy' && (
+                  <label className="flex items-center gap-3 mt-3">
+                    <span className="text-sm text-foreground">Privacy policy last updated</span>
+                    <input
+                      type="date"
+                      value={input.policy.lastUpdated}
+                      onChange={(e) => setPolicyDate(e.target.value)}
+                      className="rounded border border-border bg-background px-2 py-1 text-sm"
+                    />
+                  </label>
+                )}
+                {section.id === 'ropa' && (
+                  <label className="flex items-center gap-3 mt-3">
+                    <span className="text-sm text-foreground">RoPA last reviewed</span>
+                    <input
+                      type="date"
+                      value={input.ropa.lastReviewed}
+                      onChange={(e) => setRopaDate(e.target.value)}
+                      className="rounded border border-border bg-background px-2 py-1 text-sm"
+                    />
+                  </label>
+                )}
+              </div>
+            </section>
+          );
+        })}
+
+        {/* ── Recommendations ──────────────────────────────────────────── */}
+        <section className="rounded-lg border border-border p-6 bg-card">
+          <h2 className="text-xl font-semibold text-foreground mb-1">
+            Your prioritised recommendations
+          </h2>
+          <p className="text-sm text-muted-foreground mb-4">
+            {report.recommendations.length === 0
+              ? 'No gaps detected — your audit is clean. Verify with your DPO before relying on this result.'
+              : `${report.recommendations.length} gap${report.recommendations.length === 1 ? '' : 's'} identified, sorted by priority.`}
+          </p>
+          <ul className="space-y-3">
+            {report.recommendations.map((r, i) => (
+              <li
+                key={i}
+                className={`rounded-md border p-3 ${priorityColor(r.priority)}`}
+              >
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="text-xs font-semibold uppercase tracking-wider">{r.priority}</span>
+                  <span className="text-xs text-muted-foreground">·</span>
+                  <span className="text-xs text-muted-foreground">{r.module}</span>
+                  <span className="text-xs text-muted-foreground">·</span>
+                  <span className="text-xs text-muted-foreground">{r.ndpaSection}</span>
+                </div>
+                <p className="text-sm text-foreground font-medium mb-1">{r.label}</p>
+                <p className="text-sm text-muted-foreground">{r.recommendation}</p>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </div>
+
+      {/* ── Right column: live score (sticky on desktop) ─────────────────── */}
+      <aside className="lg:sticky lg:top-24 self-start space-y-4">
+        <div className="rounded-lg border border-border p-6 bg-card">
+          <p className="text-xs uppercase tracking-wider text-muted-foreground mb-2">Compliance score</p>
+          <div className="flex items-baseline gap-2 mb-3">
+            <span className={`text-5xl font-bold ${ratingColor(report.rating)}`}>{report.score}</span>
+            <span className="text-2xl text-muted-foreground">/ 100</span>
+          </div>
+          <p className={`text-sm font-semibold uppercase tracking-wider ${ratingColor(report.rating)}`}>
+            {report.rating}
+          </p>
+          <p className="text-xs text-muted-foreground mt-2">{ratingSummary(report.rating, report.score)}</p>
+        </div>
+
+        <div className="rounded-lg border border-border p-4 bg-card">
+          <h3 className="text-sm font-semibold text-foreground mb-3">By module</h3>
+          <ul className="space-y-2 text-xs">
+            {Object.entries(report.modules).map(([key, mod]) => (
+              <li key={key} className="flex justify-between items-center">
+                <span className="text-muted-foreground">{key}</span>
+                <span className={`font-medium ${ratingColor(moduleRating(mod.score))}`}>
+                  {Math.round(mod.score)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <EmailCaptureForm report={report} submitted={submitted} onSubmitted={() => setSubmitted(true)} />
+
+        <button
+          type="button"
+          onClick={() => window.print()}
+          className="block w-full text-center rounded-lg border border-border px-4 py-2 text-sm hover:bg-card transition"
+        >
+          Print / save as PDF
+        </button>
+
+        <Link
+          href="/docs"
+          className="block w-full text-center rounded-lg border border-border px-4 py-2 text-sm hover:bg-card transition"
+        >
+          See full toolkit docs →
+        </Link>
+
+        <p className="text-xs text-muted-foreground italic px-1">
+          Score generated for guidance only. Not legal advice — verify with your DPO or counsel.
+        </p>
+      </aside>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * Email capture
+ * ────────────────────────────────────────────────────────────────────────── */
+
+interface EmailCaptureProps {
+  report: ComplianceReport;
+  submitted: boolean;
+  onSubmitted: () => void;
+}
+
+/**
+ * Build a `mailto:` href that pre-fills the maintainer's inbox with the
+ * audit-taker's details and a Markdown digest of the top recommendations.
+ * The docs site is statically exported, so we can't run an API route in
+ * production — `mailto:` is the universal MVP path. A future patch can
+ * swap this for a real backend (Formspree, Resend, etc.) without
+ * touching the surrounding UI.
+ */
+function buildMailto(input: {
+  name: string;
+  email: string;
+  orgName: string;
+  report: ComplianceReport;
+}): string {
+  const { name, email, orgName, report } = input;
+  const subject = `NDPA audit score: ${report.score}/100 (${report.rating}) — ${orgName || name || 'audit request'}`;
+  const moduleLines = Object.entries(report.modules)
+    .map(([k, m]) => `- ${k}: ${Math.round(m.score)}/100 (${moduleRating(m.score)})`)
+    .join('\n');
+  const topRecs = report.recommendations
+    .slice(0, 10)
+    .map(
+      (r, i) =>
+        `${i + 1}. [${r.priority.toUpperCase()}] ${r.label} — ${r.ndpaSection}\n   ${r.recommendation}`,
+    )
+    .join('\n\n');
+  const body = `Hi NDPR Toolkit team,
+
+I just ran the audit at ndprtoolkit.com.ng/score and would like the PDF report.
+
+Name: ${name}
+Email: ${email}
+Organisation: ${orgName || 'n/a'}
+
+──────── Audit summary ────────
+Overall: ${report.score}/100 (${report.rating})
+
+Per-module:
+${moduleLines}
+
+──────── Top recommendations ────────
+${topRecs || 'No gaps detected.'}
+
+Generated at: ${report.generatedAt}
+
+Thanks!`;
+  return `mailto:hello@ndprtoolkit.com.ng?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+}
+
+function EmailCaptureForm({ report, submitted, onSubmitted }: EmailCaptureProps) {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [orgName, setOrgName] = useState('');
+
+  const canSubmit = name.trim().length > 0 && /.+@.+\..+/.test(email);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    // Open the user's mail client with the score pre-filled. The maintainer
+    // gets the lead in their inbox; the user keeps a copy in their sent
+    // folder. Zero backend dependency — works on the static export.
+    const href = buildMailto({ name, email, orgName, report });
+    window.location.href = href;
+    onSubmitted();
+  }
+
+  if (submitted) {
+    return (
+      <div className="rounded-lg border border-emerald-300 bg-emerald-50 dark:bg-emerald-950 dark:border-emerald-900 p-4">
+        <p className="text-sm text-foreground font-medium mb-1">✓ Email opened</p>
+        <p className="text-xs text-muted-foreground">
+          Your default email app should have opened with the score + your details pre-filled.
+          Hit send and we&apos;ll reply with the PDF report.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="rounded-lg border border-border p-4 bg-card space-y-3">
+      <h3 className="text-sm font-semibold text-foreground">Email me my PDF report</h3>
+      <p className="text-xs text-muted-foreground">
+        Detailed PDF with prioritised recommendations + NDPA section references. Free.
+      </p>
+      <input
+        type="text"
+        required
+        placeholder="Your name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        className="w-full rounded border border-border bg-background px-3 py-2 text-sm"
+      />
+      <input
+        type="email"
+        required
+        placeholder="Work email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        className="w-full rounded border border-border bg-background px-3 py-2 text-sm"
+      />
+      <input
+        type="text"
+        placeholder="Organisation (optional)"
+        value={orgName}
+        onChange={(e) => setOrgName(e.target.value)}
+        className="w-full rounded border border-border bg-background px-3 py-2 text-sm"
+      />
+      <button
+        type="submit"
+        disabled={!canSubmit}
+        className="w-full rounded-lg bg-primary text-primary-foreground px-4 py-2 text-sm font-medium hover:opacity-90 disabled:opacity-50"
+      >
+        Open mail client to send
+      </button>
+      <p className="text-[10px] text-muted-foreground leading-tight">
+        Your default email app opens with the score + your details pre-filled. We use this only
+        to send the report; unsubscribe anytime. Stored per our{' '}
+        <Link href="/privacy" className="underline">privacy policy</Link>.
+      </p>
+    </form>
+  );
+}

--- a/src/app/score/page.tsx
+++ b/src/app/score/page.tsx
@@ -1,0 +1,131 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { SiteHeader } from '@/components/site/SiteHeader';
+import { SiteFooter } from '@/components/site/SiteFooter';
+import { AuditScore } from './components/AuditScore';
+
+export const metadata: Metadata = {
+  title: 'Free Nigeria NDPA Audit — Score Your Compliance in 5 Minutes',
+  description:
+    'Free self-assessment for Nigeria Data Protection Act (NDPA) 2023 compliance. 8-section audit covering consent, DSR, DPIA, breach notification, RoPA, lawful basis, cross-border, privacy policy. Live score, prioritised recommendations with NDPA section references, downloadable PDF. No signup required to see your score.',
+  keywords:
+    'Nigeria NDPA audit, free NDPA compliance check, NDPR audit Nigeria, NDPC audit tool, Nigeria data protection self-assessment, Nigeria compliance score, NDPA 2023 audit',
+  alternates: { canonical: '/score' },
+  openGraph: {
+    title: 'Free Nigeria NDPA Audit — Score Your Compliance in 5 Minutes',
+    description:
+      'Free 8-section self-assessment for Nigeria NDPA 2023. Live score, prioritised recommendations, downloadable PDF report. No signup to see your score.',
+    url: 'https://ndprtoolkit.com.ng/score',
+    siteName: 'NDPR Toolkit',
+    images: [
+      {
+        url: '/og-image.png',
+        width: 1200,
+        height: 630,
+        alt: 'Free Nigeria NDPA Compliance Audit',
+      },
+    ],
+    locale: 'en_NG',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Free Nigeria NDPA Audit — Score in 5 Minutes',
+    description:
+      'Free 8-section NDPA 2023 self-assessment. Live score, prioritised recommendations, downloadable PDF.',
+    images: ['/og-image.png'],
+  },
+};
+
+// Static, server-rendered JSON-LD — no user input — safe to inject.
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: 'NDPR Toolkit Compliance Audit',
+  applicationCategory: 'BusinessApplication',
+  applicationSubCategory: 'Compliance / Risk Assessment',
+  operatingSystem: 'Web',
+  description:
+    'Free 8-section self-assessment for Nigeria Data Protection Act (NDPA) 2023 compliance. Covers consent, DSR, DPIA, breach notification, RoPA, lawful basis, cross-border, privacy policy. Generates a 0-100 score with prioritised recommendations.',
+  url: 'https://ndprtoolkit.com.ng/score',
+  offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+  inLanguage: ['en', 'en-NG'],
+  isAccessibleForFree: true,
+  keywords:
+    'Nigeria NDPA audit, free compliance check, NDPC audit, Section 25, Section 26, Section 28, Section 40',
+};
+
+export default function ScorePage() {
+  return (
+    <>
+      <SiteHeader />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <main className="min-h-screen max-w-6xl mx-auto px-6 py-12">
+        <header className="mb-10">
+          <p className="text-sm font-medium uppercase tracking-wider text-muted-foreground mb-3">
+            Free · No signup to see your score · ~5 minutes
+          </p>
+          <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+            Nigeria NDPA 2023 Compliance Audit
+          </h1>
+          <p className="text-lg text-muted-foreground leading-relaxed max-w-3xl">
+            Answer the 30-odd questions below to see how your organisation stacks up against the
+            gazetted Nigeria Data Protection Act 2023. Your score updates live as you fill in the
+            form. Prioritised recommendations include NDPA section references your DPO can verify
+            independently.
+          </p>
+          <p className="text-sm text-muted-foreground mt-3 max-w-3xl">
+            The scoring engine is open source — the same{' '}
+            <Link href="/docs/guides/compliance-score" className="text-primary hover:underline">
+              <code>getComplianceScore</code>
+            </Link>{' '}
+            function powers this audit, your CI pipeline, and the bundled{' '}
+            <Link href="/docs/components/hooks" className="text-primary hover:underline">
+              <code>NDPRComplianceDashboard</code>
+            </Link>{' '}
+            component. No black box.
+          </p>
+        </header>
+
+        <AuditScore />
+
+        <section className="mt-16 border-t border-border pt-10">
+          <h2 className="text-2xl font-bold text-foreground mb-4">After the audit</h2>
+          <div className="grid gap-4 md:grid-cols-3">
+            <Link
+              href="/nigeria-privacy-policy-generator"
+              className="rounded-lg border border-border p-5 hover:bg-card transition"
+            >
+              <h3 className="text-base font-semibold mb-2">Fix Section 27 gaps →</h3>
+              <p className="text-sm text-muted-foreground">
+                Generate a Nigeria-NDPA-aware privacy policy with the policy generator. Free, no signup.
+              </p>
+            </Link>
+            <Link
+              href="/nigeria-cookie-consent"
+              className="rounded-lg border border-border p-5 hover:bg-card transition"
+            >
+              <h3 className="text-base font-semibold mb-2">Fix Section 26 gaps →</h3>
+              <p className="text-sm text-muted-foreground">
+                Drop in the NDPA-compliant consent banner. Withdrawal-as-easy-as-consent built in.
+              </p>
+            </Link>
+            <Link
+              href="/ndpa-dpia-tool"
+              className="rounded-lg border border-border p-5 hover:bg-card transition"
+            >
+              <h3 className="text-base font-semibold mb-2">Fix Section 28 gaps →</h3>
+              <p className="text-sm text-muted-foreground">
+                Run a DPIA through the questionnaire tool. NDPC consultation flag included.
+              </p>
+            </Link>
+          </div>
+        </section>
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -24,6 +24,14 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 1.0,
     },
 
+    // /score audit lead-magnet (Phase C)
+    {
+      url: `${baseUrl}/score`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.95,
+    },
+
     // Long-tail SEO landing pages (Nigeria-specific queries)
     {
       url: `${baseUrl}/nigeria-cookie-consent`,

--- a/src/components/site/SiteHeader.tsx
+++ b/src/components/site/SiteHeader.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 
 const navLinks = [
+  { label: 'Audit', href: '/score' },
   { label: 'Docs', href: '/docs' },
   { label: 'Demos', href: '/ndpr-demos' },
   { label: 'Blog', href: '/blog' },


### PR DESCRIPTION
## Summary

**Phase C** — Hosted NDPA Audit Score lead-magnet. The adoption-strategy agent's #1 strategic recommendation from the original 20-agent audit. **Docs-site only — no library version bump** (uses the existing \`getComplianceScore\` API from \`@tantainnovative/ndpr-toolkit/server\`).

### New: \`/score\`

- **8-section questionnaire**, ~30 checkbox prompts + 2 dates + 1 slider. Each section labelled with the relevant NDPA section.
- **Live overall score** in a sticky right-rail card. Color-coded (excellent / good / needs-work / critical) with per-module breakdown.
- **Prioritised recommendations** — colour-coded blocks sorted by priority with NDPA section refs and one-line remediation guidance.
- **No signup wall** to see your score. Email capture is opt-in for the PDF report.

### PDF export

\`window.print()\` + a new print stylesheet in \`globals.css\` strips site chrome (header, footer, sticky right rail) so the PDF flows as a single document. Zero deps, works on every device.

### Email capture (mailto:)

The docs site is statically exported to GitHub Pages — a Next.js API route wouldn't deploy. So the form builds a \`mailto:\` href with the audit-taker's name + email + org + top-10 recommendations pre-filled and opens their mail client. Maintainer gets the lead in inbox; user keeps a copy in sent. Easy to swap for Formspree/Resend later without UI changes.

### SEO + promotion

- Full \`Metadata\` block + \`SoftwareApplication\` JSON-LD on \`/score\`
- \`/score\` added to sitemap at priority 0.95
- Title targets "free Nigeria NDPA audit" search intent

Cross-promotion across the site:
- **Homepage hero primary CTA**: flipped to "Free NDPA Audit · 5 min" (was "Get Started" — moved to secondary)
- **Site nav header**: "Audit" added as the first nav link, visible site-wide
- **3 long-tail landing pages** (\`/nigeria-cookie-consent\`, \`/ndpa-dpia-tool\`, \`/nigeria-privacy-policy-generator\`): each gets a primary-coloured CTA above the Related section

### After-the-audit cross-sell

The \`/score\` page ends with a 3-card grid linking to the matching fix:
- Section 27 gaps → privacy policy generator
- Section 26 gaps → consent banner landing
- Section 28 gaps → DPIA tool landing

### Verification

- ✅ \`tsc --noEmit\` clean (the unrelated phosphor-icons errors in \`/blog\` and \`/ndpr-demos/cross-border\` are pre-existing local install gaps, not from this PR)
- ✅ Print stylesheet tested in DevTools print preview — chrome stripped correctly
- ✅ Mailto: action assembles a complete digest of score + top-10 recommendations