### PR TITLE
feat(ndpr-toolkit): 3.9.0 — runnable examples + Bun quickstart + SSR storage guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.9.0](https://github.com/mr-tanta/ndpr-toolkit/compare/v3.8.1...v3.9.0) (2026-05-25)
+
+Examples expansion + Bun quickstart + SSR-safe storage docs. Fully additive — no breaking changes.
+
+### Runnable example apps
+
+- **`examples/ecommerce-starter`** — multi-page Next.js 15 / React 19 storefront ("Zuri Market") wiring the toolkit into a realistic Nigerian ecommerce flow: home page, checkout, privacy notice, data-subject rights portal (with `submitTo` + `onSubmitSuccess` rendering a server-issued reference), and an editable cookie preferences page using `useConsent`. Demonstrates the `/presets/consent`, `/presets/dsr`, `/presets/policy`, and `/hooks` subpaths together.
+- **`examples/ssr/nextjs-app-router`** — SSR-safe consent on Next.js 15. Layout reads the consent cookie via `next/headers`, parses it with a small typed helper, and passes the result to a client `ConsentRoot` so the banner hydrates already-resolved (no flash, no hydration warning).
+- **`examples/ssr/remix`** — the same cookie-bridge pattern wired from a Remix `loader` and Vite's `?url` asset import for the stylesheet.
+- **`examples/ssr/astro`** — `Astro.cookies.get` in the page frontmatter, then `<ConsentRoot client:load>` as a React island.
+
+Each example is self-contained (own `package.json`, `tsconfig.json`, `next.config.mjs` / `vite.config.ts` / `astro.config.mjs`) so you can copy a directory and `bun install && bun dev` to run it.
+
+### Bun quickstart in the README
+
+Root README now includes copy-pasteable Bun + Vite + React and Bun + Next.js 15 (App Router) recipes that go from zero to a working banner in three commands. The npm-published README also gets a one-line Bun install command alongside pnpm/npm.
+
+### SSR-safe storage guide
+
+New docs page at **`/docs/guides/server-side-storage`** documenting the cookie-bridge pattern in detail: why `localStorageAdapter` flashes on SSR, how `cookieAdapter` solves it, and worked examples for Next.js App Router, Remix, Astro, and SvelteKit. Wired into the docs sidebar under Implementation Guides.
+
+### npm-published README brought current (3.4.0 → 3.9.0)
+
+The README that ships to npm was stale at the 3.4.0 highlights. It now leads with a 3.9.0 "what's new", references back to 3.8.1 (`onSubmitSuccess`), 3.8.0 (Lite Manager variants), 3.6.0 (`onSubmitError`), and 3.5.x (focus management + reduced motion). Adds a "Runnable Examples" section, a typed DSR callbacks snippet in the Presets section, and a Bun install command. Screenshot URLs bumped from `v3.5.2` → `v3.9.0`. Tests badge bumped to 1173.
+
+### Verification
+
+- `tsc --noEmit` clean for the docs site
+- **Full Jest suite: 1173/1173 passing** (unchanged from 3.8.1 — no logic changes in the published package)
+- No changes to runtime exports, prop types, or storage adapters
+
 ## [3.8.1](https://github.com/mr-tanta/ndpr-toolkit/compare/v3.8.0...v3.8.1) (2026-05-25)
 
 Documentation + small API addition patch. Fully additive — no breaking changes.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,101 @@ bun create ndpr
 
 ---
 
+## Bun quickstart
+
+Bun is a first-class runtime for the toolkit. Both common React app shapes work without extra config.
+
+### Bun + Vite + React
+
+```bash
+bun create vite@latest my-ndpr-app --template react-ts
+cd my-ndpr-app
+bun install
+bun add @tantainnovative/ndpr-toolkit
+```
+
+```tsx
+// src/App.tsx
+import { NDPRConsent } from '@tantainnovative/ndpr-toolkit/presets/consent';
+import '@tantainnovative/ndpr-toolkit/styles';
+
+export default function App() {
+  return (
+    <>
+      <NDPRConsent
+        options={[
+          { id: 'essential', label: 'Essential', description: 'Required for the site to function', required: true, purpose: 'Site operation' },
+          { id: 'analytics', label: 'Analytics', description: 'Anonymous usage measurement', required: false, purpose: 'Product analytics' },
+          { id: 'marketing', label: 'Marketing', description: 'Personalised offers and ads', required: false, purpose: 'Marketing communications' },
+        ]}
+      />
+      <main className="p-6">
+        <h1 className="text-3xl font-semibold">My NDPA-compliant app</h1>
+      </main>
+    </>
+  );
+}
+```
+
+```bash
+bun dev
+```
+
+Vite is client-only by default — no extra wiring needed. The toolkit's preset components ship with the `"use client"` directive already injected.
+
+### Bun + Next.js 15 (App Router)
+
+```bash
+bun create next-app@latest my-ndpr-app --typescript --app --tailwind
+cd my-ndpr-app
+bun add @tantainnovative/ndpr-toolkit
+```
+
+The consent banner is a stateful client component. Mount it from a small client wrapper so the rest of your layout can stay in RSC:
+
+```tsx
+// app/ConsentRoot.tsx
+'use client';
+import { NDPRConsent } from '@tantainnovative/ndpr-toolkit/presets/consent';
+
+export function ConsentRoot() {
+  return (
+    <NDPRConsent
+      options={[
+        { id: 'essential', label: 'Essential', description: 'Required for the site to function', required: true, purpose: 'Site operation' },
+        { id: 'analytics', label: 'Analytics', description: 'Anonymous usage measurement', required: false, purpose: 'Product analytics' },
+        { id: 'marketing', label: 'Marketing', description: 'Personalised offers and ads', required: false, purpose: 'Marketing communications' },
+      ]}
+    />
+  );
+}
+```
+
+```tsx
+// app/layout.tsx
+import '@tantainnovative/ndpr-toolkit/styles';
+import { ConsentRoot } from './ConsentRoot';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <ConsentRoot />
+        {children}
+      </body>
+    </html>
+  );
+}
+```
+
+```bash
+bun dev
+```
+
+You don't need to manually mark the import with `"use client"` from `app/layout.tsx` — the preset module already ships the directive in its bundled output, so React Server Components import it cleanly via the client wrapper. For RSC-safe, zero-React imports use `/server` or `/core` instead.
+
+---
+
 ## Choose Your Layer
 
 Pick exactly what your project needs.
@@ -356,6 +451,7 @@ Each module ships a minimal Next.js scaffold you can fork in StackBlitz or CodeS
 
 | Module | NDPA | Open in StackBlitz | Open in CodeSandbox |
 |---|---|---|---|
+| **Ecommerce starter (full app)** | §25–27, §34–38 | [![Open](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mr-tanta/ndpr-toolkit/tree/main/examples/ecommerce-starter) | [![Open](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/github/mr-tanta/ndpr-toolkit/main/examples/ecommerce-starter) |
 | Consent | §26 | [![Open](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mr-tanta/ndpr-toolkit/tree/main/examples/stackblitz/consent) | [![Open](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/github/mr-tanta/ndpr-toolkit/main/examples/stackblitz/consent) |
 | DSR | §34 | [![Open](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mr-tanta/ndpr-toolkit/tree/main/examples/stackblitz/dsr) | [![Open](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/github/mr-tanta/ndpr-toolkit/main/examples/stackblitz/dsr) |
 | DPIA | §28 | [![Open](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mr-tanta/ndpr-toolkit/tree/main/examples/stackblitz/dpia) | [![Open](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/github/mr-tanta/ndpr-toolkit/main/examples/stackblitz/dpia) |
@@ -366,6 +462,16 @@ Each module ships a minimal Next.js scaffold you can fork in StackBlitz or CodeS
 | RoPA | §29 | [![Open](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mr-tanta/ndpr-toolkit/tree/main/examples/stackblitz/ropa) | [![Open](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/github/mr-tanta/ndpr-toolkit/main/examples/stackblitz/ropa) |
 
 Or open the [all-in-one example](https://stackblitz.com/github/mr-tanta/ndpr-toolkit/tree/main/examples/nextjs-app) that demos every module in a single app.
+
+### SSR-safe consent scaffolds
+
+Cookie-bridged consent that hydrates without a flash. Each scaffold reads the `ndpr-consent` cookie on the server, seeds the banner's `show` prop, then lets the browser `cookieAdapter` take over. See the [Server-Side Storage guide](https://ndprtoolkit.com.ng/docs/guides/server-side-storage) for the pattern.
+
+| Framework | Path | Open in StackBlitz |
+|---|---|---|
+| Next.js App Router | [`examples/ssr/nextjs-app-router`](./examples/ssr/nextjs-app-router) | [![Open](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mr-tanta/ndpr-toolkit/tree/main/examples/ssr/nextjs-app-router) |
+| Remix | [`examples/ssr/remix`](./examples/ssr/remix) | [![Open](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mr-tanta/ndpr-toolkit/tree/main/examples/ssr/remix) |
+| Astro | [`examples/ssr/astro`](./examples/ssr/astro) | [![Open](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mr-tanta/ndpr-toolkit/tree/main/examples/ssr/astro) |
 
 ---
 

--- a/examples/ecommerce-starter/README.md
+++ b/examples/ecommerce-starter/README.md
@@ -1,0 +1,68 @@
+# NDPR ecommerce starter
+
+A complete, multi-page Next.js 15 + React 19 app that wires the
+`@tantainnovative/ndpr-toolkit` modules into a realistic Nigerian ecommerce
+flow. Unlike the per-module scaffolds in `examples/stackblitz/*` (which each
+demonstrate one module in isolation), this starter shows the pieces working
+together end-to-end:
+
+- a site-wide **consent banner** (NDPA Section 26)
+- a **privacy notice** generated from the ecommerce template (Section 27)
+- a **data-subject rights portal** posting to a working API route (Sections 34–38)
+- an editable **cookie preferences** page that reads/writes the same store the
+  banner uses
+- a **checkout** flow that makes the consent / contract distinction explicit
+  (Section 25(1)(b))
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mr-tanta/ndpr-toolkit/tree/main/examples/ecommerce-starter)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/github/mr-tanta/ndpr-toolkit/main/examples/ecommerce-starter)
+
+## File tree
+
+```
+examples/ecommerce-starter/
+├── README.md
+├── package.json
+├── next.config.mjs
+├── tsconfig.json
+├── app/
+│   ├── layout.tsx              Root layout, nav, styles, ConsentRoot mount
+│   ├── page.tsx                Storefront with 3 fake products + Section 27 footer
+│   ├── ConsentRoot.tsx         Client wrapper around NDPRConsent
+│   ├── checkout/page.tsx       Demo checkout — explains consent vs contract
+│   ├── privacy/page.tsx        NDPRPrivacyPolicy seeded with the ecommerce template
+│   ├── dsr/page.tsx            NDPRSubjectRights → POSTs to /api/dsr
+│   ├── cookie-preferences/page.tsx   Toggle consent after the banner via useConsent
+│   └── api/dsr/route.ts        Working DSR endpoint — returns referenceId + ETA
+└── lib/
+    └── consent-categories.ts   Shared category list used by banner + prefs page
+```
+
+The package uses the toolkit's subpath imports — `/presets/consent`,
+`/presets/dsr`, `/presets/policy`, `/hooks` — so the example also serves as a
+guide to the granular import surface.
+
+## Run locally
+
+```sh
+bun install && bun dev
+# or
+pnpm install && pnpm dev
+# or
+npm install && npm run dev
+```
+
+Then open <http://localhost:3000>. The consent banner appears at the bottom
+on first load; clear `localStorage` to see it again.
+
+## What's intentionally NOT included
+
+- A real database — DSR submissions are accepted but not persisted.
+- Real email / SMS — production would email the data subject to verify
+  identity and notify the DPO via your case-management system.
+- A real payment provider — the checkout form is a static demo.
+- Authentication — there's no signed-in user concept here. Add NextAuth or
+  similar before shipping.
+
+For a richer reference implementation with persistence and a DPO dashboard,
+see `examples/nextjs-app/` in this repo.

--- a/examples/ecommerce-starter/app/ConsentRoot.tsx
+++ b/examples/ecommerce-starter/app/ConsentRoot.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { NDPRConsent } from "@tantainnovative/ndpr-toolkit/presets/consent";
+import { consentCategories } from "../lib/consent-categories";
+
+export function ConsentRoot() {
+  return (
+    <NDPRConsent
+      options={consentCategories}
+      position="bottom"
+      copy={{
+        title: "Your privacy on Zuri Market",
+        description:
+          "We use cookies and similar technologies to run the store, understand how it is used, and (with your permission) personalise offers. You can change your choices any time on the cookie preferences page. See our privacy notice for the full NDPA Section 27 disclosures.",
+        acceptAll: "Accept all",
+        rejectAll: "Only essentials",
+        customize: "Manage categories",
+        save: "Save preferences",
+      }}
+    />
+  );
+}

--- a/examples/ecommerce-starter/app/api/dsr/route.ts
+++ b/examples/ecommerce-starter/app/api/dsr/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+
+interface DSRSubmission {
+  requestType?: unknown;
+  dataSubject?: unknown;
+}
+
+export async function POST(request: Request) {
+  let payload: DSRSubmission;
+  try {
+    payload = (await request.json()) as DSRSubmission;
+  } catch {
+    return NextResponse.json(
+      { error: "Body must be valid JSON." },
+      { status: 400 },
+    );
+  }
+
+  if (!payload.requestType || !payload.dataSubject) {
+    return NextResponse.json(
+      { error: "Missing requestType or dataSubject." },
+      { status: 400 },
+    );
+  }
+
+  const referenceId = `DSR-${Date.now().toString(36).toUpperCase()}`;
+  const estimatedCompletionAt = new Date(
+    Date.now() + 30 * 24 * 60 * 60 * 1000,
+  ).toISOString();
+
+  // Stub. A production handler would persist this to a database, queue an
+  // identity-verification email to the data subject, and notify the DPO via
+  // their case-management system. See examples/nextjs-app for a fuller flow.
+  return NextResponse.json(
+    {
+      referenceId,
+      status: "received",
+      estimatedCompletionAt,
+    },
+    { status: 201 },
+  );
+}

--- a/examples/ecommerce-starter/app/checkout/page.tsx
+++ b/examples/ecommerce-starter/app/checkout/page.tsx
@@ -1,0 +1,92 @@
+import Link from "next/link";
+
+const pageStyle: React.CSSProperties = {
+  maxWidth: 640,
+  margin: "0 auto",
+  padding: "2.5rem 1.5rem 4rem",
+};
+
+const fieldStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.35rem",
+  marginBottom: "1rem",
+};
+
+const inputStyle: React.CSSProperties = {
+  padding: "0.625rem 0.75rem",
+  border: "1px solid #cbd5e1",
+  borderRadius: 8,
+  fontSize: "0.9375rem",
+  background: "#fff",
+};
+
+const noticeStyle: React.CSSProperties = {
+  background: "#f1f5f9",
+  border: "1px solid #cbd5e1",
+  borderRadius: 10,
+  padding: "1rem 1.25rem",
+  fontSize: "0.875rem",
+  lineHeight: 1.6,
+  color: "#334155",
+  margin: "1.5rem 0",
+};
+
+const buttonStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "0.85rem 1rem",
+  background: "#0f172a",
+  color: "#fff",
+  border: 0,
+  borderRadius: 10,
+  fontSize: "1rem",
+  fontWeight: 600,
+  cursor: "pointer",
+};
+
+export default function CheckoutPage() {
+  return (
+    <div style={pageStyle}>
+      <h1 style={{ fontSize: "1.875rem", marginBottom: "0.75rem" }}>Checkout</h1>
+      <p style={{ color: "#475569", lineHeight: 1.6 }}>
+        A demonstration checkout. Nothing is submitted — this page exists to
+        show where consent boundaries fall in a real ecommerce flow.
+      </p>
+
+      <form onSubmit={(e) => e.preventDefault()}>
+        <label style={fieldStyle}>
+          <span>Full name</span>
+          <input style={inputStyle} placeholder="Adaeze Okafor" />
+        </label>
+        <label style={fieldStyle}>
+          <span>Email</span>
+          <input style={inputStyle} type="email" placeholder="adaeze@example.ng" />
+        </label>
+        <label style={fieldStyle}>
+          <span>Delivery address</span>
+          <input style={inputStyle} placeholder="12 Awolowo Road, Ikoyi, Lagos" />
+        </label>
+        <label style={fieldStyle}>
+          <span>Card number</span>
+          <input style={inputStyle} inputMode="numeric" placeholder="0000 0000 0000 0000" />
+        </label>
+
+        <div style={noticeStyle}>
+          By placing this order, your data is processed under{" "}
+          <strong>NDPA Section 25(1)(b)</strong> (performance of a contract) —
+          we don&apos;t need your consent for that. Marketing emails, SMS, or
+          analytics tracking require separate consent, which you can grant or
+          revoke any time on{" "}
+          <Link href="/cookie-preferences" style={{ color: "#2563eb" }}>
+            cookie preferences
+          </Link>
+          .
+        </div>
+
+        <button style={buttonStyle} type="submit">
+          Place order (demo)
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/examples/ecommerce-starter/app/cookie-preferences/page.tsx
+++ b/examples/ecommerce-starter/app/cookie-preferences/page.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useConsent } from "@tantainnovative/ndpr-toolkit/hooks";
+import { consentCategories } from "../../lib/consent-categories";
+
+const pageStyle: React.CSSProperties = {
+  maxWidth: 720,
+  margin: "0 auto",
+  padding: "2.5rem 1.5rem 4rem",
+};
+
+const rowStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "flex-start",
+  justifyContent: "space-between",
+  gap: "1rem",
+  padding: "1.25rem",
+  background: "#fff",
+  border: "1px solid #e2e8f0",
+  borderRadius: 12,
+  marginBottom: "0.75rem",
+};
+
+const buttonStyle: React.CSSProperties = {
+  marginTop: "1.25rem",
+  padding: "0.75rem 1.25rem",
+  background: "#0f172a",
+  color: "#fff",
+  border: 0,
+  borderRadius: 10,
+  fontSize: "0.9375rem",
+  fontWeight: 600,
+  cursor: "pointer",
+};
+
+export default function CookiePreferencesPage() {
+  const { settings, updateConsent, isLoading } = useConsent({
+    options: consentCategories,
+  });
+
+  const [draft, setDraft] = useState<Record<string, boolean>>({});
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    if (isLoading) return;
+    const next: Record<string, boolean> = {};
+    consentCategories.forEach((opt) => {
+      next[opt.id] = opt.required
+        ? true
+        : settings?.consents[opt.id] ?? false;
+    });
+    setDraft(next);
+  }, [isLoading, settings]);
+
+  if (isLoading) {
+    return (
+      <div style={pageStyle}>
+        <p style={{ color: "#64748b" }}>Loading your saved preferences…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={pageStyle}>
+      <h1 style={{ fontSize: "1.875rem", marginBottom: "0.5rem" }}>
+        Cookie preferences
+      </h1>
+      <p style={{ color: "#475569", lineHeight: 1.6, marginBottom: "1.5rem" }}>
+        Update the consent you gave on the banner. Changes apply on this device
+        immediately. Essential cookies stay on — without them, you can&apos;t
+        place an order.
+      </p>
+
+      {consentCategories.map((opt) => (
+        <div key={opt.id} style={rowStyle}>
+          <div>
+            <strong style={{ display: "block", marginBottom: "0.25rem" }}>
+              {opt.label}
+              {opt.required && (
+                <span style={{ color: "#64748b", fontWeight: 400, marginLeft: "0.5rem", fontSize: "0.8125rem" }}>
+                  always on
+                </span>
+              )}
+            </strong>
+            <span style={{ color: "#475569", fontSize: "0.875rem", lineHeight: 1.5 }}>
+              {opt.description}
+            </span>
+          </div>
+          <label style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+            <input
+              type="checkbox"
+              checked={draft[opt.id] ?? false}
+              disabled={opt.required}
+              onChange={(e) => {
+                setDraft((prev) => ({ ...prev, [opt.id]: e.target.checked }));
+                setSaved(false);
+              }}
+              style={{ width: 20, height: 20 }}
+            />
+          </label>
+        </div>
+      ))}
+
+      <button
+        style={buttonStyle}
+        onClick={() => {
+          updateConsent(draft);
+          setSaved(true);
+        }}
+      >
+        Save preferences
+      </button>
+
+      {saved && (
+        <p style={{ color: "#065f46", marginTop: "1rem", fontSize: "0.9375rem" }}>
+          Saved. Your new preferences are now active.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/examples/ecommerce-starter/app/dsr/page.tsx
+++ b/examples/ecommerce-starter/app/dsr/page.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState } from "react";
+import { NDPRSubjectRights } from "@tantainnovative/ndpr-toolkit/presets/dsr";
+
+type Result =
+  | { kind: "idle" }
+  | { kind: "success"; referenceId: string; estimatedCompletionAt: string }
+  | { kind: "error"; message: string };
+
+const pageStyle: React.CSSProperties = {
+  maxWidth: 720,
+  margin: "0 auto",
+  padding: "2.5rem 1.5rem 4rem",
+};
+
+const calloutBase: React.CSSProperties = {
+  padding: "1rem 1.25rem",
+  borderRadius: 10,
+  marginBottom: "1.5rem",
+  fontSize: "0.9375rem",
+  lineHeight: 1.55,
+};
+
+export default function DSRPage() {
+  const [result, setResult] = useState<Result>({ kind: "idle" });
+
+  return (
+    <div style={pageStyle}>
+      <h1 style={{ fontSize: "1.875rem", marginBottom: "0.5rem" }}>
+        Your data rights
+      </h1>
+      <p style={{ color: "#475569", lineHeight: 1.6, marginBottom: "1.5rem" }}>
+        Submit a request to access, correct, export, restrict, or delete the
+        personal data Zuri Market holds about you. We respond within 30 days as
+        required by NDPA Sections 34&ndash;38.
+      </p>
+
+      {result.kind === "success" && (
+        <div
+          style={{
+            ...calloutBase,
+            background: "#ecfdf5",
+            border: "1px solid #6ee7b7",
+            color: "#065f46",
+          }}
+        >
+          <strong>Request received.</strong> Your reference is{" "}
+          <code>{result.referenceId}</code>. We&apos;ll respond by{" "}
+          {new Date(result.estimatedCompletionAt).toLocaleDateString("en-NG", {
+            day: "numeric",
+            month: "long",
+            year: "numeric",
+          })}
+          . Save this reference — you&apos;ll need it if you contact us.
+        </div>
+      )}
+
+      {result.kind === "error" && (
+        <div
+          style={{
+            ...calloutBase,
+            background: "#fef2f2",
+            border: "1px solid #fca5a5",
+            color: "#991b1b",
+          }}
+        >
+          <strong>We couldn&apos;t submit your request.</strong> {result.message}{" "}
+          Please try again, or email privacy@zuri.market.ng.
+        </div>
+      )}
+
+      <NDPRSubjectRights
+        submitTo="/api/dsr"
+        onSubmitSuccess={({ body }) => {
+          const parsed = body as
+            | { referenceId?: string; estimatedCompletionAt?: string }
+            | undefined;
+          if (parsed?.referenceId && parsed?.estimatedCompletionAt) {
+            setResult({
+              kind: "success",
+              referenceId: parsed.referenceId,
+              estimatedCompletionAt: parsed.estimatedCompletionAt,
+            });
+          } else {
+            setResult({
+              kind: "error",
+              message: "The server accepted the request but didn't return a reference.",
+            });
+          }
+        }}
+        onSubmitError={({ error, response }) => {
+          const message = response
+            ? `Server responded with ${response.status}.`
+            : error instanceof Error
+            ? error.message
+            : "Network error.";
+          setResult({ kind: "error", message });
+        }}
+      />
+    </div>
+  );
+}

--- a/examples/ecommerce-starter/app/layout.tsx
+++ b/examples/ecommerce-starter/app/layout.tsx
@@ -1,0 +1,46 @@
+import "@tantainnovative/ndpr-toolkit/styles";
+import Link from "next/link";
+import { ConsentRoot } from "./ConsentRoot";
+
+export const metadata = {
+  title: "Zuri Market — NDPR ecommerce starter",
+  description:
+    "A multi-page Next.js example wiring the NDPR toolkit into a Nigerian ecommerce flow.",
+};
+
+const navStyle: React.CSSProperties = {
+  display: "flex",
+  gap: "1.25rem",
+  flexWrap: "wrap",
+  padding: "1rem 1.5rem",
+  borderBottom: "1px solid #e2e8f0",
+  background: "#fff",
+  position: "sticky",
+  top: 0,
+  zIndex: 10,
+};
+
+const linkStyle: React.CSSProperties = {
+  color: "#0f172a",
+  textDecoration: "none",
+  fontWeight: 500,
+  fontSize: "0.9375rem",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body style={{ fontFamily: "system-ui, sans-serif", margin: 0, background: "#f8fafc", color: "#0f172a" }}>
+        <nav style={navStyle}>
+          <Link href="/" style={{ ...linkStyle, fontWeight: 700 }}>Zuri Market</Link>
+          <Link href="/checkout" style={linkStyle}>Checkout</Link>
+          <Link href="/privacy" style={linkStyle}>Privacy notice</Link>
+          <Link href="/dsr" style={linkStyle}>Your data rights</Link>
+          <Link href="/cookie-preferences" style={linkStyle}>Cookie preferences</Link>
+        </nav>
+        <main>{children}</main>
+        <ConsentRoot />
+      </body>
+    </html>
+  );
+}

--- a/examples/ecommerce-starter/app/page.tsx
+++ b/examples/ecommerce-starter/app/page.tsx
@@ -1,0 +1,105 @@
+import Link from "next/link";
+
+const products = [
+  {
+    id: "ankara-tote",
+    name: "Adire Ankara tote",
+    price: 18500,
+    description: "Hand-stitched Lagos-made tote in indigo adire.",
+  },
+  {
+    id: "kente-pouch",
+    name: "Kente pocket pouch",
+    price: 7200,
+    description: "Small zip pouch lined with cotton, woven in Aba.",
+  },
+  {
+    id: "shea-set",
+    name: "Northern shea butter set",
+    price: 12400,
+    description: "Three 100g tubs of unrefined shea, sourced from Kano cooperatives.",
+  },
+];
+
+const naira = new Intl.NumberFormat("en-NG", {
+  style: "currency",
+  currency: "NGN",
+  maximumFractionDigits: 0,
+});
+
+const pageStyle: React.CSSProperties = {
+  maxWidth: 960,
+  margin: "0 auto",
+  padding: "2.5rem 1.5rem 4rem",
+};
+
+const gridStyle: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+  gap: "1.25rem",
+  marginTop: "1.75rem",
+};
+
+const cardStyle: React.CSSProperties = {
+  background: "#fff",
+  border: "1px solid #e2e8f0",
+  borderRadius: 12,
+  padding: "1.25rem",
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.5rem",
+};
+
+const footerStyle: React.CSSProperties = {
+  marginTop: "3rem",
+  padding: "1.5rem",
+  background: "#fff",
+  border: "1px solid #e2e8f0",
+  borderRadius: 12,
+  fontSize: "0.875rem",
+  color: "#475569",
+  lineHeight: 1.6,
+};
+
+export default function HomePage() {
+  return (
+    <div style={pageStyle}>
+      <h1 style={{ fontSize: "2rem", marginBottom: "0.5rem" }}>Zuri Market</h1>
+      <p style={{ color: "#475569", lineHeight: 1.6, maxWidth: 640 }}>
+        A fictional Nigerian retailer showing how the NDPR toolkit fits into a
+        realistic ecommerce flow: consent banner, privacy notice, data-subject
+        rights portal, and an editable cookie preferences page — all working
+        together.
+      </p>
+
+      <div style={gridStyle}>
+        {products.map((p) => (
+          <article key={p.id} style={cardStyle}>
+            <h2 style={{ fontSize: "1.0625rem", margin: 0 }}>{p.name}</h2>
+            <p style={{ color: "#64748b", fontSize: "0.875rem", margin: 0 }}>{p.description}</p>
+            <strong style={{ color: "#0f172a", fontSize: "1.125rem", marginTop: "auto" }}>
+              {naira.format(p.price)}
+            </strong>
+            <Link
+              href="/checkout"
+              style={{ color: "#2563eb", textDecoration: "none", fontSize: "0.875rem" }}
+            >
+              Add to cart and checkout
+            </Link>
+          </article>
+        ))}
+      </div>
+
+      <footer style={footerStyle}>
+        <strong style={{ color: "#0f172a" }}>Section 27 disclosure.</strong>{" "}
+        Zuri Market Ltd (RC 0000000) is the data controller for personal data
+        you share on this site. We process your data to fulfil orders (NDPA
+        Section 25(1)(b)) and, with your consent, for analytics, marketing,
+        and personalisation. Read the full notice in our{" "}
+        <Link href="/privacy" style={{ color: "#2563eb" }}>privacy notice</Link>{" "}
+        or exercise your rights via the{" "}
+        <Link href="/dsr" style={{ color: "#2563eb" }}>data rights portal</Link>.
+      </footer>
+    </div>
+  );
+}

--- a/examples/ecommerce-starter/app/privacy/page.tsx
+++ b/examples/ecommerce-starter/app/privacy/page.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { NDPRPrivacyPolicy } from "@tantainnovative/ndpr-toolkit/presets/policy";
+
+export default function PrivacyPage() {
+  return (
+    <div style={{ maxWidth: 960, margin: "0 auto", padding: "2.5rem 1.5rem 4rem" }}>
+      <h1 style={{ fontSize: "1.875rem", marginBottom: "0.5rem" }}>Privacy notice</h1>
+      <p style={{ color: "#475569", lineHeight: 1.6, marginBottom: "1.5rem" }}>
+        Generated with the toolkit&apos;s adaptive wizard, seeded with the{" "}
+        <code>ecommerce</code> template. Walk through each section to see the
+        NDPA Section 27 disclosures a Nigerian retailer is expected to publish.
+      </p>
+
+      <NDPRPrivacyPolicy
+        template="ecommerce"
+        templateOverrides={{
+          orgName: "Zuri Market Ltd",
+          website: "https://zuri.market.ng",
+          privacyEmail: "privacy@zuri.market.ng",
+          dpoName: "Ifeoma Adeyemi",
+          dpoEmail: "dpo@zuri.market.ng",
+        }}
+      />
+    </div>
+  );
+}

--- a/examples/ecommerce-starter/lib/consent-categories.ts
+++ b/examples/ecommerce-starter/lib/consent-categories.ts
@@ -1,0 +1,40 @@
+import type { ConsentOption } from "@tantainnovative/ndpr-toolkit";
+
+export const consentCategories: ConsentOption[] = [
+  {
+    id: "essential",
+    label: "Essential",
+    description:
+      "Required to keep you signed in, hold your cart, and process orders. Cannot be disabled.",
+    required: true,
+    purpose: "Site operation and order fulfilment under NDPA Section 25(1)(b).",
+    defaultValue: true,
+  },
+  {
+    id: "analytics",
+    label: "Analytics",
+    description:
+      "Helps us understand which products and pages are most useful so we can improve the store.",
+    required: false,
+    purpose: "Aggregate product analytics.",
+    defaultValue: false,
+  },
+  {
+    id: "marketing",
+    label: "Marketing",
+    description:
+      "Used to send you offers by email and SMS, and to measure the performance of our ads.",
+    required: false,
+    purpose: "Direct marketing communications.",
+    defaultValue: false,
+  },
+  {
+    id: "personalization",
+    label: "Personalization",
+    description:
+      "Remembers your size, address, and recently viewed items to tailor your experience.",
+    required: false,
+    purpose: "Storefront personalisation.",
+    defaultValue: false,
+  },
+];

--- a/examples/ecommerce-starter/next.config.mjs
+++ b/examples/ecommerce-starter/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  transpilePackages: ["@tantainnovative/ndpr-toolkit"],
+};
+
+export default nextConfig;

--- a/examples/ecommerce-starter/package.json
+++ b/examples/ecommerce-starter/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "ndpr-ecommerce-starter",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@tantainnovative/ndpr-toolkit": "^3.9.0",
+    "next": "^15.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/examples/ecommerce-starter/tsconfig.json
+++ b/examples/ecommerce-starter/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/examples/ssr/astro/README.md
+++ b/examples/ssr/astro/README.md
@@ -1,0 +1,38 @@
+# NDPR Toolkit — Astro SSR example
+
+Minimal Astro 5 scaffold (server output, Node adapter) that demonstrates the **cookie-bridge
+pattern** for rendering the `@tantainnovative/ndpr-toolkit` consent banner without a hydration
+flash.
+
+## The pattern
+
+- `src/pages/index.astro` runs on the server. Its frontmatter calls
+  `Astro.cookies.get("ndpr-consent")?.value`, then parses the value with the shared helper from
+  `src/lib/parse-consent-cookie.ts`.
+- The parsed `ConsentSettings | null` is passed as a prop into the React island
+  `<ConsentRoot client:load initialConsent={...} />`. JSON survives the Astro → React boundary.
+- `src/components/ConsentRoot.tsx` is a React component that owns the `cookieAdapter` and
+  renders `<ConsentBanner show={!hasFreshConsent} manageStorage={false} ... />`. The adapter
+  writes back through the same cookie on save.
+
+Astro defaults to static output. This scaffold sets `output: "server"` in `astro.config.mjs`
+because the cookie bridge requires a request — there is none at build time.
+
+## Cookie name
+
+`ndpr-consent` — exported as `CONSENT_COOKIE` from `src/lib/parse-consent-cookie.ts`.
+
+## Run it
+
+```bash
+pnpm install
+pnpm dev
+```
+
+Then open http://localhost:4321.
+
+## Why `manageStorage={false}`
+
+`<ConsentBanner>` defaults to talking to `localStorage` directly. In this scaffold the
+`cookieAdapter` owns persistence end to end, so we disable the banner's built-in storage and
+write through `adapter.save(settings)` from `onSave`.

--- a/examples/ssr/astro/astro.config.mjs
+++ b/examples/ssr/astro/astro.config.mjs
@@ -1,0 +1,9 @@
+import { defineConfig } from "astro/config";
+import node from "@astrojs/node";
+import react from "@astrojs/react";
+
+export default defineConfig({
+  output: "server",
+  adapter: node({ mode: "standalone" }),
+  integrations: [react()],
+});

--- a/examples/ssr/astro/package.json
+++ b/examples/ssr/astro/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "ndpr-ssr-astro",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "@astrojs/node": "^9.0.0",
+    "@astrojs/react": "^4.0.0",
+    "@tantainnovative/ndpr-toolkit": "^3.9.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "astro": "^5.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0"
+  }
+}

--- a/examples/ssr/astro/src/components/ConsentRoot.tsx
+++ b/examples/ssr/astro/src/components/ConsentRoot.tsx
@@ -1,0 +1,33 @@
+import { useMemo } from "react";
+import { ConsentBanner } from "@tantainnovative/ndpr-toolkit/consent";
+import { cookieAdapter } from "@tantainnovative/ndpr-toolkit/adapters";
+import type { ConsentSettings, ConsentOption } from "@tantainnovative/ndpr-toolkit";
+import { CONSENT_COOKIE } from "../lib/parse-consent-cookie";
+
+const OPTIONS: ConsentOption[] = [
+  { id: "essential", label: "Essential", description: "Required for site operation.", required: true, purpose: "Site operation" },
+  { id: "analytics", label: "Analytics", description: "Usage statistics.", required: false, purpose: "Analytics" },
+  { id: "marketing", label: "Marketing", description: "Targeted advertising.", required: false, purpose: "Advertising" },
+];
+
+const CONSENT_VERSION = "1.0";
+
+export function ConsentRoot({ initialConsent }: { initialConsent: ConsentSettings | null }) {
+  const adapter = useMemo(
+    () => cookieAdapter<ConsentSettings>(CONSENT_COOKIE, { sameSite: "Lax", secure: true, expires: 365 }),
+    []
+  );
+
+  const hasFreshConsent =
+    initialConsent?.hasInteracted === true && initialConsent.version === CONSENT_VERSION;
+
+  return (
+    <ConsentBanner
+      options={OPTIONS}
+      version={CONSENT_VERSION}
+      manageStorage={false}
+      show={!hasFreshConsent}
+      onSave={(settings) => adapter.save(settings)}
+    />
+  );
+}

--- a/examples/ssr/astro/src/lib/parse-consent-cookie.ts
+++ b/examples/ssr/astro/src/lib/parse-consent-cookie.ts
@@ -1,0 +1,17 @@
+import type { ConsentSettings } from "@tantainnovative/ndpr-toolkit";
+
+export const CONSENT_COOKIE = "ndpr-consent";
+
+export function parseConsentCookie(raw: string | undefined): ConsentSettings | null {
+  if (!raw) return null;
+  try {
+    const decoded = decodeURIComponent(raw);
+    const parsed = JSON.parse(decoded) as ConsentSettings;
+    if (typeof parsed !== "object" || parsed === null) return null;
+    if (typeof parsed.timestamp !== "number") return null;
+    if (typeof parsed.consents !== "object" || parsed.consents === null) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}

--- a/examples/ssr/astro/src/pages/index.astro
+++ b/examples/ssr/astro/src/pages/index.astro
@@ -1,0 +1,31 @@
+---
+import "@tantainnovative/ndpr-toolkit/styles";
+import { ConsentRoot } from "../components/ConsentRoot";
+import { CONSENT_COOKIE, parseConsentCookie } from "../lib/parse-consent-cookie";
+
+const initialConsent = parseConsentCookie(Astro.cookies.get(CONSENT_COOKIE)?.value);
+---
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>NDPR Toolkit — Astro SSR consent</title>
+  </head>
+  <body style="font-family: system-ui, sans-serif; margin: 0">
+    <main style="max-width: 720px; margin: 0 auto; padding: 3rem 1.5rem">
+      <h1 style="font-size: 1.875rem; margin-bottom: 0.75rem">
+        SSR-safe consent on Astro
+      </h1>
+      <p style="color: #475569; line-height: 1.6; margin-bottom: 1rem">
+        The Astro frontmatter reads <code>ndpr-consent</code> via <code>Astro.cookies.get</code>,
+        parses it, and passes the result to a React island. The banner hydrates already showing
+        or already hidden — no flash.
+      </p>
+      <p style="color: #64748b; font-size: 0.875rem">
+        Accept categories and refresh: the server-rendered HTML comes back with the banner
+        closed.
+      </p>
+    </main>
+    <ConsentRoot client:load initialConsent={initialConsent} />
+  </body>
+</html>

--- a/examples/ssr/astro/tsconfig.json
+++ b/examples/ssr/astro/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "react"
+  },
+  "include": ["src/**/*", ".astro/types.d.ts"],
+  "exclude": ["dist"]
+}

--- a/examples/ssr/nextjs-app-router/README.md
+++ b/examples/ssr/nextjs-app-router/README.md
@@ -1,0 +1,37 @@
+# NDPR Toolkit — Next.js App Router SSR example
+
+Minimal Next.js 15 + React 19 scaffold that demonstrates the **cookie-bridge pattern** for
+rendering the `@tantainnovative/ndpr-toolkit` consent banner without a hydration flash.
+
+## The pattern
+
+- `app/layout.tsx` is a Server Component that reads `ndpr-consent` from the request via
+  `cookies()` (from `next/headers`), parses it with the shared helper, and passes the parsed
+  `ConsentSettings | null` as a prop to `app/ConsentRoot.tsx`.
+- `app/ConsentRoot.tsx` is a client component that owns the `cookieAdapter` and renders
+  `<ConsentBanner show={!hasFreshConsent} manageStorage={false} ... />`. The cookie name passed
+  to `cookieAdapter` must match the name read on the server — both use the `CONSENT_COOKIE`
+  constant from `app/lib/parse-consent-cookie.ts`.
+
+The browser-side `cookieAdapter` writes back to the same cookie on save, so the next SSR pass
+sees the user's choice and renders the banner closed.
+
+## Cookie name
+
+`ndpr-consent` — exported as `CONSENT_COOKIE` from `app/lib/parse-consent-cookie.ts`.
+
+## Run it
+
+```bash
+pnpm install
+pnpm dev
+```
+
+Then open http://localhost:3000. Accept or customize the banner; refresh; observe that the
+banner does not flash open before disappearing.
+
+## Why `manageStorage={false}`
+
+`<ConsentBanner>` defaults to talking to `localStorage` directly. In this scaffold the
+`cookieAdapter` owns persistence end to end, so we turn the banner's built-in storage off and
+write through `adapter.save(settings)` from the `onSave` callback.

--- a/examples/ssr/nextjs-app-router/app/ConsentRoot.tsx
+++ b/examples/ssr/nextjs-app-router/app/ConsentRoot.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useMemo } from "react";
+import { ConsentBanner } from "@tantainnovative/ndpr-toolkit/consent";
+import { cookieAdapter } from "@tantainnovative/ndpr-toolkit/adapters";
+import type { ConsentSettings, ConsentOption } from "@tantainnovative/ndpr-toolkit";
+import { CONSENT_COOKIE } from "./lib/parse-consent-cookie";
+
+const OPTIONS: ConsentOption[] = [
+  { id: "essential", label: "Essential", description: "Required for site operation.", required: true, purpose: "Site operation" },
+  { id: "analytics", label: "Analytics", description: "Usage statistics.", required: false, purpose: "Analytics" },
+  { id: "marketing", label: "Marketing", description: "Targeted advertising.", required: false, purpose: "Advertising" },
+];
+
+const CONSENT_VERSION = "1.0";
+
+export function ConsentRoot({
+  initialConsent,
+  children,
+}: {
+  initialConsent: ConsentSettings | null;
+  children: React.ReactNode;
+}) {
+  const adapter = useMemo(
+    () => cookieAdapter<ConsentSettings>(CONSENT_COOKIE, { sameSite: "Lax", secure: true, expires: 365 }),
+    []
+  );
+
+  const hasFreshConsent =
+    initialConsent?.hasInteracted === true && initialConsent.version === CONSENT_VERSION;
+
+  return (
+    <>
+      {children}
+      <ConsentBanner
+        options={OPTIONS}
+        version={CONSENT_VERSION}
+        manageStorage={false}
+        show={!hasFreshConsent}
+        onSave={(settings) => adapter.save(settings)}
+      />
+    </>
+  );
+}

--- a/examples/ssr/nextjs-app-router/app/layout.tsx
+++ b/examples/ssr/nextjs-app-router/app/layout.tsx
@@ -1,0 +1,23 @@
+import { cookies } from "next/headers";
+import "@tantainnovative/ndpr-toolkit/styles";
+import { ConsentRoot } from "./ConsentRoot";
+import { CONSENT_COOKIE, parseConsentCookie } from "./lib/parse-consent-cookie";
+
+export const metadata = {
+  title: "NDPR Toolkit — Next.js SSR consent",
+  description:
+    "Cookie-bridged SSR for the @tantainnovative/ndpr-toolkit consent banner in Next.js App Router.",
+};
+
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const cookieStore = await cookies();
+  const initialConsent = parseConsentCookie(cookieStore.get(CONSENT_COOKIE)?.value);
+
+  return (
+    <html lang="en">
+      <body style={{ fontFamily: "system-ui, sans-serif", margin: 0 }}>
+        <ConsentRoot initialConsent={initialConsent}>{children}</ConsentRoot>
+      </body>
+    </html>
+  );
+}

--- a/examples/ssr/nextjs-app-router/app/lib/parse-consent-cookie.ts
+++ b/examples/ssr/nextjs-app-router/app/lib/parse-consent-cookie.ts
@@ -1,0 +1,17 @@
+import type { ConsentSettings } from "@tantainnovative/ndpr-toolkit";
+
+export const CONSENT_COOKIE = "ndpr-consent";
+
+export function parseConsentCookie(raw: string | undefined): ConsentSettings | null {
+  if (!raw) return null;
+  try {
+    const decoded = decodeURIComponent(raw);
+    const parsed = JSON.parse(decoded) as ConsentSettings;
+    if (typeof parsed !== "object" || parsed === null) return null;
+    if (typeof parsed.timestamp !== "number") return null;
+    if (typeof parsed.consents !== "object" || parsed.consents === null) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}

--- a/examples/ssr/nextjs-app-router/app/page.tsx
+++ b/examples/ssr/nextjs-app-router/app/page.tsx
@@ -1,0 +1,18 @@
+export default function Home() {
+  return (
+    <main style={{ maxWidth: 720, margin: "0 auto", padding: "3rem 1.5rem" }}>
+      <h1 style={{ fontSize: "1.875rem", marginBottom: "0.75rem" }}>
+        SSR-safe consent on Next.js App Router
+      </h1>
+      <p style={{ color: "#475569", lineHeight: 1.6, marginBottom: "1rem" }}>
+        The consent state is read from the <code>ndpr-consent</code> cookie inside the root layout
+        Server Component, then forwarded to a client wrapper as the initial value. The banner
+        therefore renders in its final visibility on the first paint — no hydration flash.
+      </p>
+      <p style={{ color: "#64748b", fontSize: "0.875rem" }}>
+        Choose categories in the banner, then refresh: the banner stays hidden because the cookie
+        is now set and the server-rendered HTML never includes the open banner.
+      </p>
+    </main>
+  );
+}

--- a/examples/ssr/nextjs-app-router/next.config.mjs
+++ b/examples/ssr/nextjs-app-router/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  transpilePackages: ["@tantainnovative/ndpr-toolkit"],
+};
+
+export default nextConfig;

--- a/examples/ssr/nextjs-app-router/package.json
+++ b/examples/ssr/nextjs-app-router/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "ndpr-ssr-nextjs-app-router",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@tantainnovative/ndpr-toolkit": "^3.9.0",
+    "next": "^15.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/examples/ssr/nextjs-app-router/tsconfig.json
+++ b/examples/ssr/nextjs-app-router/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": { "@/*": ["./*"] },
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/examples/ssr/remix/README.md
+++ b/examples/ssr/remix/README.md
@@ -1,0 +1,36 @@
+# NDPR Toolkit — Remix SSR example
+
+Minimal Remix (Vite) scaffold that demonstrates the **cookie-bridge pattern** for
+rendering the `@tantainnovative/ndpr-toolkit` consent banner without a hydration flash.
+
+## The pattern
+
+- `app/root.tsx` exposes a `loader` that calls `readConsentFromRequest(request)` from
+  `app/lib/parse-consent-cookie.ts`. The helper pulls `ndpr-consent` from
+  `request.headers.get("cookie")`, decodes it, and validates the shape.
+- The default `<App>` component reads the parsed value via `useLoaderData` and forwards it to
+  `<ConsentRoot initialConsent={...} />`.
+- `app/components/ConsentRoot.tsx` instantiates `cookieAdapter<ConsentSettings>("ndpr-consent")`
+  and renders `<ConsentBanner show={!hasFreshConsent} manageStorage={false} ... />`. The
+  adapter writes back through the same cookie on save, so the next SSR pass renders the banner
+  closed.
+
+## Cookie name
+
+`ndpr-consent` — exported as `CONSENT_COOKIE` from `app/lib/parse-consent-cookie.ts`.
+
+## Run it
+
+```bash
+pnpm install
+pnpm dev
+```
+
+Then open http://localhost:3000.
+
+## Why `manageStorage={false}`
+
+`<ConsentBanner>` defaults to talking to `localStorage` directly. In this scaffold the
+`cookieAdapter` owns persistence end to end, so we turn the banner's built-in storage off and
+write through `adapter.save(settings)` from `onSave`. The same cookie is the canonical record
+on both server and client.

--- a/examples/ssr/remix/app/components/ConsentRoot.tsx
+++ b/examples/ssr/remix/app/components/ConsentRoot.tsx
@@ -1,0 +1,33 @@
+import { useMemo } from "react";
+import { ConsentBanner } from "@tantainnovative/ndpr-toolkit/consent";
+import { cookieAdapter } from "@tantainnovative/ndpr-toolkit/adapters";
+import type { ConsentSettings, ConsentOption } from "@tantainnovative/ndpr-toolkit";
+import { CONSENT_COOKIE } from "~/lib/parse-consent-cookie";
+
+const OPTIONS: ConsentOption[] = [
+  { id: "essential", label: "Essential", description: "Required for site operation.", required: true, purpose: "Site operation" },
+  { id: "analytics", label: "Analytics", description: "Usage statistics.", required: false, purpose: "Analytics" },
+  { id: "marketing", label: "Marketing", description: "Targeted advertising.", required: false, purpose: "Advertising" },
+];
+
+const CONSENT_VERSION = "1.0";
+
+export function ConsentRoot({ initialConsent }: { initialConsent: ConsentSettings | null }) {
+  const adapter = useMemo(
+    () => cookieAdapter<ConsentSettings>(CONSENT_COOKIE, { sameSite: "Lax", secure: true, expires: 365 }),
+    []
+  );
+
+  const hasFreshConsent =
+    initialConsent?.hasInteracted === true && initialConsent.version === CONSENT_VERSION;
+
+  return (
+    <ConsentBanner
+      options={OPTIONS}
+      version={CONSENT_VERSION}
+      manageStorage={false}
+      show={!hasFreshConsent}
+      onSave={(settings) => adapter.save(settings)}
+    />
+  );
+}

--- a/examples/ssr/remix/app/lib/parse-consent-cookie.ts
+++ b/examples/ssr/remix/app/lib/parse-consent-cookie.ts
@@ -1,0 +1,27 @@
+import type { ConsentSettings } from "@tantainnovative/ndpr-toolkit";
+
+export const CONSENT_COOKIE = "ndpr-consent";
+
+export function parseConsentCookie(raw: string | undefined): ConsentSettings | null {
+  if (!raw) return null;
+  try {
+    const decoded = decodeURIComponent(raw);
+    const parsed = JSON.parse(decoded) as ConsentSettings;
+    if (typeof parsed !== "object" || parsed === null) return null;
+    if (typeof parsed.timestamp !== "number") return null;
+    if (typeof parsed.consents !== "object" || parsed.consents === null) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function readConsentFromRequest(request: Request): ConsentSettings | null {
+  const header = request.headers.get("cookie") ?? "";
+  const prefix = `${CONSENT_COOKIE}=`;
+  const match = header
+    .split(";")
+    .map((c) => c.trim())
+    .find((c) => c.startsWith(prefix));
+  return parseConsentCookie(match?.slice(prefix.length));
+}

--- a/examples/ssr/remix/app/root.tsx
+++ b/examples/ssr/remix/app/root.tsx
@@ -1,0 +1,39 @@
+import { json, type LinksFunction, type LoaderFunctionArgs } from "@remix-run/node";
+import {
+  Links,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+  useLoaderData,
+} from "@remix-run/react";
+import toolkitStyles from "@tantainnovative/ndpr-toolkit/styles?url";
+
+import { ConsentRoot } from "~/components/ConsentRoot";
+import { readConsentFromRequest } from "~/lib/parse-consent-cookie";
+
+export const links: LinksFunction = () => [{ rel: "stylesheet", href: toolkitStyles }];
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  return json({ initialConsent: readConsentFromRequest(request) });
+}
+
+export default function App() {
+  const { initialConsent } = useLoaderData<typeof loader>();
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <Meta />
+        <Links />
+      </head>
+      <body style={{ fontFamily: "system-ui, sans-serif", margin: 0 }}>
+        <Outlet />
+        <ConsentRoot initialConsent={initialConsent} />
+        <ScrollRestoration />
+        <Scripts />
+      </body>
+    </html>
+  );
+}

--- a/examples/ssr/remix/app/routes/_index.tsx
+++ b/examples/ssr/remix/app/routes/_index.tsx
@@ -1,0 +1,28 @@
+import type { MetaFunction } from "@remix-run/node";
+
+export const meta: MetaFunction = () => [
+  { title: "NDPR Toolkit — Remix SSR consent" },
+  {
+    name: "description",
+    content: "Cookie-bridged SSR consent banner in Remix using @tantainnovative/ndpr-toolkit.",
+  },
+];
+
+export default function Index() {
+  return (
+    <main style={{ maxWidth: 720, margin: "0 auto", padding: "3rem 1.5rem" }}>
+      <h1 style={{ fontSize: "1.875rem", marginBottom: "0.75rem" }}>
+        SSR-safe consent on Remix
+      </h1>
+      <p style={{ color: "#475569", lineHeight: 1.6, marginBottom: "1rem" }}>
+        The root loader reads the <code>ndpr-consent</code> cookie from the request, parses it,
+        and exposes it via <code>useLoaderData</code> to <code>&lt;ConsentRoot&gt;</code>. The
+        banner hydrates already showing or already hidden — no flash.
+      </p>
+      <p style={{ color: "#64748b", fontSize: "0.875rem" }}>
+        Accept categories, refresh, and watch the server-rendered HTML come back with the banner
+        closed.
+      </p>
+    </main>
+  );
+}

--- a/examples/ssr/remix/package.json
+++ b/examples/ssr/remix/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "ndpr-ssr-remix",
+  "version": "0.1.0",
+  "private": true,
+  "sideEffects": false,
+  "type": "module",
+  "scripts": {
+    "build": "remix vite:build",
+    "dev": "remix vite:dev",
+    "start": "remix-serve ./build/server/index.js",
+    "typecheck": "tsc"
+  },
+  "dependencies": {
+    "@remix-run/node": "^2.13.0",
+    "@remix-run/react": "^2.13.0",
+    "@remix-run/serve": "^2.13.0",
+    "@tantainnovative/ndpr-toolkit": "^3.9.0",
+    "isbot": "^4.4.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@remix-run/dev": "^2.13.0",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "typescript": "^5.5.0",
+    "vite": "^5.4.0",
+    "vite-tsconfig-paths": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/examples/ssr/remix/tsconfig.json
+++ b/examples/ssr/remix/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "include": ["**/*.ts", "**/*.tsx", "**/.server/**/*.ts", "**/.client/**/*.ts"],
+  "compilerOptions": {
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "target": "ES2022",
+    "strict": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": { "~/*": ["./app/*"] },
+    "noEmit": true
+  }
+}

--- a/examples/ssr/remix/vite.config.ts
+++ b/examples/ssr/remix/vite.config.ts
@@ -1,0 +1,7 @@
+import { vitePlugin as remix } from "@remix-run/dev";
+import { defineConfig } from "vite";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [remix(), tsconfigPaths()],
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tantainnovative/ndpr-toolkit",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "private": false,
   "description": "Nigeria Data Protection Toolkit — enterprise-grade compliance components for the Nigeria Data Protection Act (NDPA) 2023",
   "pnpm": {

--- a/packages/ndpr-toolkit/README.md
+++ b/packages/ndpr-toolkit/README.md
@@ -6,17 +6,19 @@
 [![npm downloads](https://img.shields.io/npm/dm/@tantainnovative/ndpr-toolkit.svg)](https://www.npmjs.com/package/@tantainnovative/ndpr-toolkit)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5%2B-3178C6.svg)](https://www.typescriptlang.org/)
-[![Tests](https://img.shields.io/badge/tests-1098%20passing-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/tests-1173%20passing-brightgreen.svg)](#)
 [![Bundle Size](https://img.shields.io/bundlephobia/minzip/@tantainnovative/ndpr-toolkit)](https://bundlephobia.com/package/@tantainnovative/ndpr-toolkit)
 
 v3 ships **zero-config presets**, **pluggable storage adapters**, **compound components**, and a **compliance score engine** — eight production-ready modules covering consent, data subject rights, DPIA, breach notification, privacy policies, lawful basis, cross-border transfers, and ROPA.
 
-**[Documentation](https://ndprtoolkit.com.ng)** | **[Live Demos](https://ndprtoolkit.com.ng/ndpr-demos)** | **[npm](https://www.npmjs.com/package/@tantainnovative/ndpr-toolkit)** | **[Blog](https://ndprtoolkit.com.ng/blog)** | **[v3.4.0 Release](https://github.com/mr-tanta/ndpr-toolkit/releases/tag/v3.4.0)**
+**[Documentation](https://ndprtoolkit.com.ng)** | **[Live Demos](https://ndprtoolkit.com.ng/ndpr-demos)** | **[npm](https://www.npmjs.com/package/@tantainnovative/ndpr-toolkit)** | **[Blog](https://ndprtoolkit.com.ng/blog)** | **[v3.9.0 Release](https://github.com/mr-tanta/ndpr-toolkit/releases/tag/v3.9.0)**
 
-> **What's new in 3.4.0:** components now ship styled defaults via a real stylesheet — Tailwind is no longer required. Add `import "@tantainnovative/ndpr-toolkit/styles";` once in your app entry. Plus a new `/server` subpath for RSC-safe pure-logic imports (validators, generators, scoring) with zero React in the import graph. Backward-compatible at the component API level. Full notes on the [release page](https://github.com/mr-tanta/ndpr-toolkit/releases/tag/v3.4.0).
+> **What's new in 3.9.0:** runnable example apps — a full multi-page Nigerian ecommerce starter (`examples/ecommerce-starter`) and SSR-safe cookie-bridge templates for Next.js App Router, Remix, and Astro (`examples/ssr/*`). README now ships a Bun + Vite and Bun + Next.js 15 quickstart. A new docs guide at `/docs/guides/server-side-storage` covers the SSR consent pattern end-to-end. Fully additive on top of 3.8.x — no breaking changes.
+>
+> **3.8.1** added a typed `onSubmitSuccess` callback to `NDPRSubjectRights`, a documented DSR submission payload contract, accessibility notes on the banner + DSR form, and a 3.5 → 3.8 migration guide. **3.8.0** shipped Lite (read-only) variants of the heavy Manager components for read paths (`/lawful-basis/lite`, `/cross-border/lite`, `/ropa/lite`). **3.6.0** added a typed `onSubmitError({ error, response })` callback. **3.5.x** added focus management (`useFocusTrap`), escape-to-dismiss, and `prefers-reduced-motion` support across all overlays. Full notes on the [release page](https://github.com/mr-tanta/ndpr-toolkit/releases/tag/v3.9.0).
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/mr-tanta/ndpr-toolkit/v3.5.2/public/screenshots/hero.png" alt="NDPA Toolkit — NDPA Compliance Made Beautiful" width="800" />
+  <img src="https://raw.githubusercontent.com/mr-tanta/ndpr-toolkit/v3.9.0/public/screenshots/hero.png" alt="NDPA Toolkit — NDPA Compliance Made Beautiful" width="800" />
 </p>
 
 ---
@@ -65,7 +67,7 @@ import { apiAdapter } from '@tantainnovative/ndpr-toolkit/adapters';
 That's it. NDPA-compliant consent with server-side persistence in under 20 lines.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/mr-tanta/ndpr-toolkit/v3.5.2/public/screenshots/consent-demo.png" alt="Consent Management Demo — interactive consent banner with state inspector" width="800" />
+  <img src="https://raw.githubusercontent.com/mr-tanta/ndpr-toolkit/v3.9.0/public/screenshots/consent-demo.png" alt="Consent Management Demo — interactive consent banner with state inspector" width="800" />
   <br />
   <em>Interactive consent demo with configurable position, theme, storage, and real-time state inspector</em>
 </p>
@@ -76,6 +78,10 @@ That's it. NDPA-compliant consent with server-side persistence in under 20 lines
 
 ```bash
 pnpm add @tantainnovative/ndpr-toolkit
+# or
+bun add @tantainnovative/ndpr-toolkit
+# or
+npm install @tantainnovative/ndpr-toolkit
 ```
 
 Add the stylesheet import once in your app entry so components render with default styles:
@@ -118,6 +124,29 @@ import {
   NDPRDPIA,              // DPIA questionnaire
   NDPRComplianceDashboard, // Visual compliance dashboard
 } from '@tantainnovative/ndpr-toolkit/presets';
+```
+
+The DSR preset wires submission directly to your backend with typed success and error callbacks (3.6.0 + 3.8.1):
+
+```tsx
+<NDPRSubjectRights
+  submitTo="/api/dsr"
+  onSubmitSuccess={({ response, data, body }) => {
+    const ref = (body as { referenceId?: string })?.referenceId;
+    if (ref) router.push(`/dsr-confirmation?ref=${ref}`);
+  }}
+  onSubmitError={({ error, response }) => {
+    console.error('DSR submit failed', error, response?.status);
+  }}
+/>
+```
+
+For read-only Manager surfaces (audits, dashboards) where the editing UI is overkill, the **Lite** variants ship a much smaller subset (3.8.0):
+
+```tsx
+import { LawfulBasisLite } from '@tantainnovative/ndpr-toolkit/lawful-basis/lite';
+import { CrossBorderTransferLite } from '@tantainnovative/ndpr-toolkit/cross-border/lite';
+import { ROPALite } from '@tantainnovative/ndpr-toolkit/ropa/lite';
 ```
 
 ### Components — compound pattern
@@ -311,18 +340,34 @@ Every module has an interactive demo. No signup, no setup — try them instantly
 
 <p align="center">
   <a href="https://ndprtoolkit.com.ng/ndpr-demos">
-    <img src="https://raw.githubusercontent.com/mr-tanta/ndpr-toolkit/v3.5.2/public/screenshots/demos-overview.png" alt="8 interactive live demos — zero setup required" width="800" />
+    <img src="https://raw.githubusercontent.com/mr-tanta/ndpr-toolkit/v3.9.0/public/screenshots/demos-overview.png" alt="8 interactive live demos — zero setup required" width="800" />
   </a>
 </p>
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/mr-tanta/ndpr-toolkit/v3.5.2/public/screenshots/dsr-demo.png" alt="Data Subject Rights — 8 rights with request tracking" width="400" />
-  <img src="https://raw.githubusercontent.com/mr-tanta/ndpr-toolkit/v3.5.2/public/screenshots/breach-demo.png" alt="Breach Notification — 72-hour countdown with step-by-step workflow" width="400" />
+  <img src="https://raw.githubusercontent.com/mr-tanta/ndpr-toolkit/v3.9.0/public/screenshots/dsr-demo.png" alt="Data Subject Rights — 8 rights with request tracking" width="400" />
+  <img src="https://raw.githubusercontent.com/mr-tanta/ndpr-toolkit/v3.9.0/public/screenshots/breach-demo.png" alt="Breach Notification — 72-hour countdown with step-by-step workflow" width="400" />
 </p>
 
 <p align="center">
   <em>Left: Data Subject Rights portal with 8 NDPA rights. Right: Breach notification with 72-hour NDPC deadline countdown.</em>
 </p>
+
+---
+
+## Runnable Examples
+
+Self-contained starter apps in the [examples/](https://github.com/mr-tanta/ndpr-toolkit/tree/main/examples) directory. Clone, install, run.
+
+| Example | What it shows | Stack |
+|---------|--------------|-------|
+| [`examples/ecommerce-starter`](https://github.com/mr-tanta/ndpr-toolkit/tree/main/examples/ecommerce-starter) | Multi-page Nigerian ecommerce with consent banner, privacy notice, DSR portal, and editable cookie preferences | Next.js 15 App Router + React 19 |
+| [`examples/ssr/nextjs-app-router`](https://github.com/mr-tanta/ndpr-toolkit/tree/main/examples/ssr/nextjs-app-router) | SSR-safe consent: cookie read on the server, banner hydrates already-resolved (no flash) | Next.js 15 App Router |
+| [`examples/ssr/remix`](https://github.com/mr-tanta/ndpr-toolkit/tree/main/examples/ssr/remix) | Same cookie-bridge pattern from a Remix `loader` | Remix + Vite |
+| [`examples/ssr/astro`](https://github.com/mr-tanta/ndpr-toolkit/tree/main/examples/ssr/astro) | Cookie read in Astro frontmatter, banner mounted as a `client:load` React island | Astro + React |
+| [`examples/stackblitz/consent`](https://github.com/mr-tanta/ndpr-toolkit/tree/main/examples/stackblitz/consent) | Minimal sandbox-ready consent banner | Next.js |
+
+Full SSR pattern documented at **[`/docs/guides/server-side-storage`](https://ndprtoolkit.com.ng/docs/guides/server-side-storage)**.
 
 ---
 

--- a/packages/ndpr-toolkit/package.json
+++ b/packages/ndpr-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tantainnovative/ndpr-toolkit",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "description": "React and TypeScript compliance components for the Nigeria Data Protection Act (NDPA) 2023",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/app/docs/guides/server-side-storage/page.tsx
+++ b/src/app/docs/guides/server-side-storage/page.tsx
@@ -1,0 +1,349 @@
+'use client';
+
+import Link from 'next/link';
+import { DocLayout } from '@/components/docs/DocLayout';
+
+export default function ServerSideStorageGuide() {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'TechArticle',
+    headline: 'SSR-safe storage for the NDPA Toolkit — cookie-bridge pattern',
+    description:
+      'Patterns for rendering the NDPA Toolkit consent state on the server in Next.js App Router, Remix, Astro, and SvelteKit. Read the consent cookie on the server, seed initial UI state, and let the browser cookieAdapter take over after hydration.',
+    author: { '@type': 'Person', name: 'Abraham Esandayinze Tanta' },
+    publisher: { '@type': 'Organization', name: 'NDPA Toolkit', url: 'https://ndprtoolkit.com.ng' },
+    about: { '@type': 'SoftwareApplication', name: 'NDPA Toolkit' },
+    keywords: [
+      'SSR consent banner',
+      'Next.js App Router cookies',
+      'Remix loader cookies',
+      'Astro cookies',
+      'SvelteKit cookies',
+      'ndpr-toolkit',
+    ],
+  };
+
+  const jsonLdString = JSON.stringify(jsonLd);
+
+  return (
+    <DocLayout
+      title="Server-Side Storage & SSR-safe Consent"
+      description="Read the consent cookie on the server, seed initial state, then let the cookieAdapter take over on the client. Patterns for Next.js, Remix, Astro, and SvelteKit."
+    >
+      <script
+        type="application/ld+json"
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: jsonLdString }}
+      />
+
+      <section id="overview" className="mb-10">
+        <h2 className="text-2xl font-bold text-foreground mt-12 mb-4">Overview</h2>
+        <p className="mb-4 text-foreground leading-relaxed">
+          The toolkit&apos;s default persistence layer is <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">localStorageAdapter</code>.
+          That works fine in a SPA but on the server <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">window</code>{' '}
+          and <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">localStorage</code> are undefined. The consent state
+          is therefore rendered as &quot;unset&quot; on the server, then revealed-or-hidden during hydration when the
+          adapter finally runs in the browser — a visible flash and, with strict hydration, a console warning.
+        </p>
+        <p className="mb-4 text-foreground leading-relaxed">
+          <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">cookieAdapter</code> works
+          in the browser too (it uses <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">document.cookie</code>),
+          but the same cookie is visible to the framework&apos;s request API on the server. That gives you a
+          single source of truth that both sides can read. The pattern:
+        </p>
+        <ol className="list-decimal pl-6 space-y-2 text-foreground mb-4">
+          <li>Configure the toolkit on the client with <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">cookieAdapter</code> so writes land in a cookie.</li>
+          <li>In your server-rendering layer, read that same cookie from the request headers.</li>
+          <li>Parse the JSON payload and pass it as initial state to the client component that hosts the banner.</li>
+          <li>The banner now hydrates in the correct state (visible only when consent is missing or stale). The cookieAdapter handles every subsequent read and write on the client.</li>
+        </ol>
+        <p className="mb-4 text-foreground leading-relaxed">
+          You do not need a new server-side adapter — the existing <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">cookieAdapter</code> at
+          <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">@tantainnovative/ndpr-toolkit/adapters</code> is the persistence layer in
+          both directions. The server just needs to read the same cookie name.
+        </p>
+      </section>
+
+      <section id="cookie-bridge" className="mb-10">
+        <h2 className="text-2xl font-bold text-foreground mt-12 mb-4">Pattern: cookie-bridged SSR initial state</h2>
+        <p className="mb-4 text-foreground">
+          The cookie name you read on the server <strong>must match</strong> the key you pass to{' '}
+          <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">cookieAdapter</code> on
+          the client. The examples below use <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">ndpr-consent</code>{' '}
+          throughout. The full setup is three pieces:
+        </p>
+        <ul className="list-disc pl-6 space-y-2 text-foreground mb-4">
+          <li><strong>A server bit</strong> that reads <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">ndpr-consent</code> from the request cookies.</li>
+          <li><strong>A small parser</strong> that decodes <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">decodeURIComponent(JSON.stringify(T))</code> back into a typed object.</li>
+          <li><strong>A client component</strong> that receives the parsed value as a prop and feeds it into{' '}
+            <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">{'<ConsentBanner show={...}>'}</code> so the banner does not flash open while consent already exists.</li>
+        </ul>
+      </section>
+
+      <section id="nextjs" className="mb-10">
+        <h2 className="text-2xl font-bold text-foreground mt-12 mb-4">Next.js App Router (RSC)</h2>
+        <p className="mb-4 text-foreground">
+          Read the cookie in <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">app/layout.tsx</code>{' '}
+          (a Server Component) and forward the parsed value to a client wrapper:
+        </p>
+        <div className="bg-card border border-border rounded-xl p-4 overflow-x-auto mb-4">
+          <pre className="text-foreground"><code>{`// app/layout.tsx
+import { cookies } from 'next/headers';
+import { parseConsentCookie } from '@/lib/parse-consent-cookie';
+import { ConsentRoot } from './ConsentRoot';
+import '@tantainnovative/ndpr-toolkit/styles';
+
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const cookieStore = await cookies();
+  const initialConsent = parseConsentCookie(cookieStore.get('ndpr-consent')?.value);
+
+  return (
+    <html lang="en">
+      <body>
+        <ConsentRoot initialConsent={initialConsent}>{children}</ConsentRoot>
+      </body>
+    </html>
+  );
+}`}</code></pre>
+        </div>
+        <div className="bg-card border border-border rounded-xl p-4 overflow-x-auto mb-4">
+          <pre className="text-foreground"><code>{`// app/ConsentRoot.tsx
+'use client';
+
+import { useMemo } from 'react';
+import { ConsentBanner } from '@tantainnovative/ndpr-toolkit/consent';
+import { cookieAdapter } from '@tantainnovative/ndpr-toolkit/adapters';
+import type { ConsentSettings, ConsentOption } from '@tantainnovative/ndpr-toolkit';
+
+const OPTIONS: ConsentOption[] = [
+  { id: 'essential', label: 'Essential', description: 'Required.', required: true, purpose: 'Site operation' },
+  { id: 'analytics', label: 'Analytics', description: 'Usage stats.', required: false, purpose: 'Analytics' },
+];
+
+export function ConsentRoot({
+  initialConsent,
+  children,
+}: { initialConsent: ConsentSettings | null; children: React.ReactNode }) {
+  const adapter = useMemo(() => cookieAdapter<ConsentSettings>('ndpr-consent'), []);
+  const hasConsent = initialConsent?.hasInteracted === true;
+
+  return (
+    <>
+      {children}
+      <ConsentBanner
+        options={OPTIONS}
+        manageStorage={false}
+        show={!hasConsent}
+        onSave={(settings) => adapter.save(settings)}
+      />
+    </>
+  );
+}`}</code></pre>
+        </div>
+        <p className="mb-4 text-foreground">
+          <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">manageStorage={'{false}'}</code>{' '}
+          tells the banner not to talk to <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">localStorage</code> directly —{' '}
+          the cookie adapter owns persistence end to end. <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">show</code>{' '}
+          is derived from server-parsed state, so the banner is rendered in its final visibility on the first paint.
+        </p>
+      </section>
+
+      <section id="remix" className="mb-10">
+        <h2 className="text-2xl font-bold text-foreground mt-12 mb-4">Remix</h2>
+        <p className="mb-4 text-foreground">
+          Parse the cookie inside a <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">loader</code> and read it via{' '}
+          <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">useLoaderData</code> in the component:
+        </p>
+        <div className="bg-card border border-border rounded-xl p-4 overflow-x-auto mb-4">
+          <pre className="text-foreground"><code>{`// app/root.tsx
+import { json, type LoaderFunctionArgs } from '@remix-run/node';
+import { Outlet, useLoaderData } from '@remix-run/react';
+import { parseConsentCookie } from '~/lib/parse-consent-cookie';
+import { ConsentRoot } from '~/components/ConsentRoot';
+import '@tantainnovative/ndpr-toolkit/styles';
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const header = request.headers.get('cookie') ?? '';
+  const match = header.split(';').map((c) => c.trim()).find((c) => c.startsWith('ndpr-consent='));
+  const raw = match?.slice('ndpr-consent='.length);
+  return json({ initialConsent: parseConsentCookie(raw) });
+}
+
+export default function App() {
+  const { initialConsent } = useLoaderData<typeof loader>();
+  return (
+    <html lang="en">
+      <body>
+        <ConsentRoot initialConsent={initialConsent}>
+          <Outlet />
+        </ConsentRoot>
+      </body>
+    </html>
+  );
+}`}</code></pre>
+        </div>
+        <p className="mb-4 text-foreground">
+          <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">ConsentRoot</code>{' '}
+          here is the same client wrapper as the Next.js example — it imports{' '}
+          <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">ConsentBanner</code>{' '}
+          and <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">cookieAdapter</code>, decides{' '}
+          <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">show</code> from the prop, and writes through the adapter on save.
+          Remix has no <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">{'"use client"'}</code> boundary;
+          every component runs in both environments, so no separate file is strictly required.
+        </p>
+      </section>
+
+      <section id="astro" className="mb-10">
+        <h2 className="text-2xl font-bold text-foreground mt-12 mb-4">Astro</h2>
+        <p className="mb-4 text-foreground">
+          Astro pages run on the server by default. Use{' '}
+          <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">Astro.cookies.get</code> in the frontmatter and pass the parsed value into a React island:
+        </p>
+        <div className="bg-card border border-border rounded-xl p-4 overflow-x-auto mb-4">
+          <pre className="text-foreground"><code>{`---
+// src/pages/index.astro
+import { parseConsentCookie } from '../lib/parse-consent-cookie';
+import { ConsentRoot } from '../components/ConsentRoot';
+import '@tantainnovative/ndpr-toolkit/styles';
+
+const initialConsent = parseConsentCookie(Astro.cookies.get('ndpr-consent')?.value);
+---
+<html lang="en">
+  <body>
+    <main>
+      <h1>Welcome</h1>
+    </main>
+    <ConsentRoot client:load initialConsent={initialConsent} />
+  </body>
+</html>`}</code></pre>
+        </div>
+        <p className="mb-4 text-foreground">
+          <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">client:load</code>{' '}
+          hydrates the React island immediately. The prop passed across the bridge is plain JSON so it
+          survives serialisation; the island itself is the same{' '}
+          <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">ConsentRoot</code> as before.
+        </p>
+      </section>
+
+      <section id="sveltekit" className="mb-10">
+        <h2 className="text-2xl font-bold text-foreground mt-12 mb-4">SvelteKit</h2>
+        <p className="mb-4 text-foreground">
+          The toolkit&apos;s UI is React-only, so this applies if you mount the React banner via a wrapper
+          such as <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">svelte-react</code>{' '}
+          or run it inside a Svelte component shell. The server side of the pattern is unchanged:
+        </p>
+        <div className="bg-card border border-border rounded-xl p-4 overflow-x-auto mb-4">
+          <pre className="text-foreground"><code>{`// src/routes/+layout.server.ts
+import type { LayoutServerLoad } from './$types';
+import { parseConsentCookie } from '$lib/parse-consent-cookie';
+
+export const load: LayoutServerLoad = ({ cookies }) => ({
+  initialConsent: parseConsentCookie(cookies.get('ndpr-consent')),
+});`}</code></pre>
+        </div>
+        <p className="mb-4 text-foreground">
+          The value is then available as <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">data.initialConsent</code> in{' '}
+          <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">+layout.svelte</code> and can be forwarded to the React island.
+        </p>
+      </section>
+
+      <section id="cookie-format" className="mb-10">
+        <h2 className="text-2xl font-bold text-foreground mt-12 mb-4">Reading the cookie format</h2>
+        <p className="mb-4 text-foreground">
+          The shape that lands in the cookie is the toolkit&apos;s{' '}
+          <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">ConsentSettings</code> object,
+          serialised with <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">JSON.stringify</code> and then URL-encoded.
+          The relevant source is <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">packages/ndpr-toolkit/src/adapters/cookie.ts</code> at line 30.
+          The matching parser is small and shared by every framework:
+        </p>
+        <div className="bg-card border border-border rounded-xl p-4 overflow-x-auto mb-4">
+          <pre className="text-foreground"><code>{`// lib/parse-consent-cookie.ts
+import type { ConsentSettings } from '@tantainnovative/ndpr-toolkit';
+
+export function parseConsentCookie(raw: string | undefined): ConsentSettings | null {
+  if (!raw) return null;
+  try {
+    const decoded = decodeURIComponent(raw);
+    const parsed = JSON.parse(decoded) as ConsentSettings;
+    if (typeof parsed !== 'object' || parsed === null) return null;
+    if (typeof parsed.timestamp !== 'number') return null;
+    if (typeof parsed.consents !== 'object') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}`}</code></pre>
+        </div>
+        <p className="mb-4 text-foreground">
+          The shape validation is deliberately narrow — if the cookie is corrupt, tampered, or was written by an
+          older version of the toolkit, returning <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">null</code>{' '}
+          means the banner re-opens and the user re-consents. Failing closed is the correct default for a
+          consent record under NDPA Section 26.
+        </p>
+      </section>
+
+      <section id="caveats" className="mb-10">
+        <h2 className="text-2xl font-bold text-foreground mt-12 mb-4">Caveats</h2>
+        <h3 className="text-lg font-semibold text-foreground mt-6 mb-3">Cookie size limits</h3>
+        <p className="mb-4 text-foreground">
+          Browsers cap a single cookie at roughly 4 KB. The default{' '}
+          <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">ConsentSettings</code> payload is well under 1 KB,
+          but if you push large <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">dataCategories</code> arrays into
+          each option you can outgrow that. If the payload starts approaching the limit, store only the minimal
+          decision map in the cookie and keep the full settings server-side keyed by a session cookie.
+        </p>
+        <h3 className="text-lg font-semibold text-foreground mt-6 mb-3">Cookie security</h3>
+        <p className="mb-4 text-foreground">
+          The toolkit&apos;s <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">cookieAdapter</code> writes with{' '}
+          <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">SameSite=Lax</code> and{' '}
+          <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">Secure</code> by default. Both are appropriate for a
+          consent cookie. Do <strong>not</strong> set <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">HttpOnly</code> —
+          the client needs to read it to render the banner and to write updates. If your threat model includes
+          XSS-based consent tampering, store the canonical consent record server-side and treat the cookie as a hint.
+        </p>
+        <h3 className="text-lg font-semibold text-foreground mt-6 mb-3">SSR/CSR mismatch</h3>
+        <p className="mb-4 text-foreground">
+          The bridge eliminates the visible flash but only if the server-parsed cookie matches what the client
+          would compute. Two ways that can drift:
+        </p>
+        <ul className="list-disc pl-6 space-y-2 text-foreground mb-4">
+          <li>The cookie name on the server differs from the key passed to <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">cookieAdapter</code> on the client. Keep both at <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">ndpr-consent</code> or pull the name from a shared constant.</li>
+          <li>The version pinned on the banner via <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">{'<ConsentBanner version="...">'}</code> changes. The banner treats a stale version as &quot;needs re-consent&quot;, so derive <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">show</code> from <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">parsed?.version === currentVersion</code>, not from <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">hasInteracted</code> alone.</li>
+        </ul>
+        <h3 className="text-lg font-semibold text-foreground mt-6 mb-3">Edge cases per framework</h3>
+        <p className="mb-4 text-foreground">
+          The pattern works in every server-rendered React framework that exposes a request-cookie API. It does{' '}
+          <strong>not</strong> apply to static export (<code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">next export</code>,
+          Astro&apos;s default <code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">output: &apos;static&apos;</code>) because
+          there is no request and therefore no cookie to read at build time. Use SSR (<code className="bg-card border border-border px-1.5 py-0.5 rounded text-sm">output: &apos;server&apos;</code>)
+          or fall back to the default localStorage adapter and accept the hydration flash.
+        </p>
+      </section>
+
+      <section id="see-also" className="mb-10">
+        <h2 className="text-2xl font-bold text-foreground mt-12 mb-4">See also</h2>
+        <ul className="list-disc pl-6 space-y-2 text-foreground">
+          <li>
+            <Link href="/docs/guides/server-rendering" className="text-primary hover:underline">
+              Server Rendering &amp; RSC
+            </Link>{' '}
+            — the <code className="bg-muted px-1 py-0.5 rounded">/server</code> entry, validators, and policy generation.
+          </li>
+          <li>
+            <Link href="/docs/guides/adapters" className="text-primary hover:underline">
+              Storage Adapters
+            </Link>{' '}
+            — full reference for <code className="bg-muted px-1 py-0.5 rounded">cookieAdapter</code>,{' '}
+            <code className="bg-muted px-1 py-0.5 rounded">composeAdapters</code>, and friends.
+          </li>
+          <li>
+            <Link href="/docs/guides/managing-consent" className="text-primary hover:underline">
+              Managing Consent
+            </Link>{' '}
+            — NDPA Section 25-26 obligations and the banner&apos;s lifecycle.
+          </li>
+        </ul>
+      </section>
+    </DocLayout>
+  );
+}

--- a/src/components/docs/DocLayout.tsx
+++ b/src/components/docs/DocLayout.tsx
@@ -63,6 +63,7 @@ const navigation: NavItem[] = [
       { title: 'Lite vs Full managers', href: '/docs/guides/lite-vs-full', isNew: true },
       { title: 'Styling Architecture', href: '/docs/guides/styling-architecture', isNew: true },
       { title: 'Server Rendering & RSC', href: '/docs/guides/server-rendering', isNew: true },
+      { title: 'Server-Side Storage (SSR)', href: '/docs/guides/server-side-storage', isNew: true },
       { title: 'NDPA Compliance Checklist', href: '/docs/guides/ndpr-compliance-checklist' },
       { title: 'Conducting a DPIA', href: '/docs/guides/conducting-dpia' },
       { title: 'Managing Consent', href: '/docs/guides/managing-consent' },


### PR DESCRIPTION
## Summary

Phase I of the feedback work — examples expansion. Fully additive on top of 3.8.1, no breaking changes.

### Runnable example apps (`examples/`)

- **`examples/ecommerce-starter`** — multi-page Next.js 15 / React 19 storefront ("Zuri Market") wiring `/presets/consent`, `/presets/dsr`, `/presets/policy`, and `/hooks`. DSR portal renders a server-issued reference via `onSubmitSuccess`. Realistic Nigerian retailer flow with home, checkout, privacy notice, DSR portal, and editable cookie preferences.
- **`examples/ssr/nextjs-app-router`** — cookie-bridge SSR: layout reads `ndpr-consent` via `next/headers`, banner hydrates already-resolved (no flash, no hydration warning).
- **`examples/ssr/remix`** — same pattern from a Remix `loader` + Vite `?url` stylesheet import.
- **`examples/ssr/astro`** — `Astro.cookies.get` in frontmatter, `<ConsentRoot client:load>` React island.

Each example is self-contained (own `package.json`, `tsconfig.json`, framework config) so users can copy a directory and run `bun install && bun dev`.

### Docs

- New **`/docs/guides/server-side-storage`** guide covering the cookie bridge end-to-end with worked Next.js / Remix / Astro / SvelteKit recipes. Wired into the Implementation Guides sidebar.

### READMEs

- **Root README** — adds Bun + Vite + React and Bun + Next.js 15 quickstarts. Also fixes a small API bug in the snippet I introduced earlier: should be `options` / `label` / `purpose` (the real `ConsentOption` shape), not `categories` / `name`.
- **npm-published README** (`packages/ndpr-toolkit/README.md`) — was stale at v3.4.0 highlights. Now leads with 3.9.0 "what's new", references 3.8.1 / 3.8.0 / 3.6.0 / 3.5.x highlights, adds a Runnable Examples table, typed DSR callbacks snippet (`onSubmitSuccess` + `onSubmitError`), Lite Manager components note, Bun install command. Screenshot URLs bumped `v3.5.2` → `v3.9.0`. Tests badge bumped to 1173.

## Test plan

- [x] `jest --no-coverage` — **1173 / 1173 passing**
- [x] `tsc --noEmit` — docs site clean
- [ ] After merge: npm publish workflow picks up the new tag and the npm page shows the updated README