### PR TITLE
fix(build): repair dts-rollup sweep + wire /headless into root tsup (3.10.1)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Verify entry points
         run: |
-          for entry in index core server hooks adapters presets consent dsr dpia breach policy lawful-basis cross-border ropa lawful-basis-lite cross-border-lite ropa-lite unstyled presets-consent presets-dsr presets-policy; do
+          for entry in index core server hooks headless adapters presets consent dsr dpia breach policy lawful-basis cross-border ropa lawful-basis-lite cross-border-lite ropa-lite unstyled presets-consent presets-dsr presets-policy; do
             for ext in js mjs d.ts; do
               if [ ! -f "dist/$entry.$ext" ]; then
                 echo "MISSING: dist/$entry.$ext"
@@ -64,7 +64,7 @@ jobs:
             echo "MISSING: dist/styles.css"
             exit 1
           fi
-          echo "All 21 entry points + styles.css verified"
+          echo "All 22 entry points + styles.css verified"
 
       - name: Verify package version matches release tag
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.10.1](https://github.com/mr-tanta/ndpr-toolkit/compare/v3.10.0...v3.10.1) (2026-05-25)
+
+Hotfix release. Code and runtime are identical to 3.10.0 — this patch fixes the build/publish pipeline that silently failed every release from 3.8.0 onward, so 3.10.1 is the first version since 3.7.0 to actually reach npm.
+
+### Root cause
+
+The dts-rollup post-build step (`scripts/rollup-dts.mjs`) deletes "leftover" hash-suffixed declaration files that tsup emits alongside each rolled-up entry. The 3.8.0 release added new entry names with two hyphens (`lawful-basis-lite`, `cross-border-lite`) — and the hash-suffix regex `/-[A-Za-z0-9_-]{8,}\.d\.m?ts$/` matched those legitimate entries because the trailing `basis-lite` / `border-lite` segments fall inside the 8-char dash-inclusive window. The sweep then deleted `dist/lawful-basis-lite.d.ts` and `dist/cross-border-lite.d.ts` right after rollup, the workflow's entry-points check then failed, and `npm publish` never ran. The git tags / GitHub releases for 3.8.0, 3.8.1, 3.9.0, and 3.10.0 existed; only npm was stuck on 3.7.0.
+
+### Fix
+
+- Replaced the regex-based sweep with an explicit allowlist (`new Set([...ENTRIES, 'styles'])`). Any `.d.ts` / `.d.mts` whose basename isn't in the allowed entries gets swept. No more pattern matching against names.
+- Wired the 3.10.0 `/headless` entry into the root `tsup.config.ts` (it had only been wired in `packages/ndpr-toolkit/tsup.config.ts`, which the publish workflow doesn't use) and added it to `CLIENT_ENTRIES` so the `"use client"` banner is injected.
+- Workflow's `Verify entry points` step now covers 22 entries (was 21) — added `headless`.
+
+### Recovery
+
+After this patch lands and 3.10.1 publishes successfully, the failed tags (v3.8.0, v3.8.1, v3.9.0, v3.10.0) will be backfilled to npm by cherry-picking this fix onto each tagged commit and re-running the workflow.
+
 ## [3.10.0](https://github.com/mr-tanta/ndpr-toolkit/compare/v3.9.0...v3.10.0) (2026-05-25)
 
 Phase J of the feedback work — new API surface (theme provider + headless alias) and a production-grade DSR backend reference. Fully additive — no breaking changes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tantainnovative/ndpr-toolkit",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "private": false,
   "description": "Nigeria Data Protection Toolkit — enterprise-grade compliance components for the Nigeria Data Protection Act (NDPA) 2023",
   "pnpm": {

--- a/packages/ndpr-toolkit/package.json
+++ b/packages/ndpr-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tantainnovative/ndpr-toolkit",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "React and TypeScript compliance components for the Nigeria Data Protection Act (NDPA) 2023",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/scripts/rollup-dts.mjs
+++ b/scripts/rollup-dts.mjs
@@ -22,6 +22,7 @@ const ENTRIES = [
   'core',
   'server',
   'hooks',
+  'headless',
   'consent',
   'dsr',
   'dpia',
@@ -104,23 +105,32 @@ for (const entry of ENTRIES) {
 // Clean up the temp config.
 if (existsSync(TMP_CONFIG)) unlinkSync(TMP_CONFIG);
 
-// Sweep up the now-orphaned chunk .d.ts and .d.mts files. They're inlined
-// into the rolled-up entries so consumers no longer reach them.
-const chunkFiles = (await fs.readdir(DIST))
-  .filter((f) => /^chunk-[A-Z0-9_-]+\.d\.m?ts$/.test(f));
-for (const f of chunkFiles) {
+// Sweep up every .d.ts / .d.mts file that ISN'T one of our published
+// entries. After dts-rollup runs, the entry files are fully self-contained
+// (every referenced declaration is inlined), so the per-symbol and chunk
+// files that tsup emitted alongside them are dead weight and broke IDE
+// "go to definition" links because their content-hashes rotate per release.
+//
+// We keep an explicit allowlist (built from ENTRIES + 'styles') instead of
+// pattern-matching the hash suffix. The older regex approach
+// (`-[A-Za-z0-9_-]{8,}\.d\.m?ts$`) accidentally matched legitimate
+// hyphenated entry names like `lawful-basis-lite.d.ts` and
+// `cross-border-lite.d.ts` — the trailing `basis-lite` / `border-lite`
+// segments fall inside the dash-inclusive 8-char window. That bug shipped
+// in 3.8.0 and silently failed every npm publish from 3.8.0 through
+// 3.10.0: the publish workflow's entry-points check then errored before
+// `npm publish` ever ran, leaving npm stuck on 3.7.0.
+const allowed = new Set([...ENTRIES, 'styles']);
+const allDts = (await fs.readdir(DIST))
+  .filter((f) => /\.d\.m?ts$/.test(f));
+let swept = 0;
+for (const f of allDts) {
+  const base = f.replace(/\.d\.m?ts$/, '');
+  if (allowed.has(base)) continue;
   await fs.unlink(path.join(DIST, f));
-}
-
-// Also sweep any remaining hash-suffixed component .d.{m,}ts files
-// (e.g. `useDefaultPrivacyPolicy-DkOqMg2e.d.ts`). These were the symptom
-// FINLAB flagged — broken doc links per release.
-const hashSuffixedFiles = (await fs.readdir(DIST))
-  .filter((f) => /-[A-Za-z0-9_-]{8,}\.d\.m?ts$/.test(f));
-for (const f of hashSuffixedFiles) {
-  await fs.unlink(path.join(DIST, f));
+  swept++;
 }
 
 console.log(
-  `\n  rolled up ${processed} entries, skipped ${skipped}, swept ${chunkFiles.length + hashSuffixedFiles.length} chunk/hash dts files`,
+  `\n  rolled up ${processed} entries, skipped ${skipped}, swept ${swept} chunk/hash dts files`,
 );

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -15,6 +15,7 @@ const RSC_SAFE_ENTRIES = ["core", "server"];
 const CLIENT_ENTRIES = [
   "index",
   "hooks",
+  "headless",
   "consent",
   "dsr",
   "dpia",
@@ -39,6 +40,9 @@ export default defineConfig({
     core: `${PKG}/core.ts`,
     server: `${PKG}/server.ts`,
     hooks: `${PKG}/hooks-entry.ts`,
+    // Alias of /hooks under a more discoverable name (3.10.0). Re-exports
+    // every hook from hooks-entry.ts; same surface, different import path.
+    headless: `${PKG}/headless.ts`,
     consent: `${PKG}/consent.ts`,
     dsr: `${PKG}/dsr.ts`,
     dpia: `${PKG}/dpia.ts`,


### PR DESCRIPTION
## Summary

**Every npm publish since 3.7.0 has silently failed.** GitHub shows v3.8.0 / v3.8.1 / v3.9.0 / v3.10.0 as released, but npm's latest is still v3.7.0.

Root cause: a hash-suffix regex in \`scripts/rollup-dts.mjs\` accidentally matches legitimate entry names with multiple hyphens.

The regex \`/-[A-Za-z0-9_-]{8,}\.d\.m?ts$/\` was meant to catch tsup chunks like \`useDefaultPrivacyPolicy-DkOqMg2e.d.ts\`. It also matches:

- \`lawful-basis-lite.d.ts\` → matches via \`-basis-lite\` (10 chars in \`[A-Za-z0-9_-]\`)
- \`cross-border-lite.d.ts\` → matches via \`-border-lite\`

(\`ropa-lite.d.ts\` survived because \`-lite\` is only 4 chars.)

Both Lite entries shipped in 3.8.0, so the workflow's \`Verify entry points\` step has failed with \`MISSING: dist/lawful-basis-lite.d.ts\` on every release since.

## Fix

- \`scripts/rollup-dts.mjs\` — replaced the regex with an explicit allowlist (\`Set([...ENTRIES, 'styles'])\`). Anything else is swept. No more name-pattern matching.
- \`tsup.config.ts\` — added the 3.10.0 \`/headless\` entry (J2 only wired it in \`packages/ndpr-toolkit/tsup.config.ts\`, but \`build:lib\` uses the root config). Added to \`CLIENT_ENTRIES\` so the \`"use client"\` banner is injected.
- \`.github/workflows/publish.yml\` — \`Verify entry points\` loop now covers 22 entries (was 21), including \`headless\`.

## Test plan

- [x] \`pnpm build:lib\` locally produces all 22 entries × {\`.js\`, \`.mjs\`, \`.d.ts\`} + \`dist/styles.css\`
- [x] The workflow's exact verification loop passes locally
- [ ] After merge: tag v3.10.1, watch the publish run actually reach \`npm publish\` for the first time since 3.7.0
- [ ] Backfill v3.8.0 / v3.8.1 / v3.9.0 / v3.10.0 to npm by cherry-picking this commit onto each tagged commit and re-running the workflow