### PR TITLE
fix(readme): root README header so npm page reflects current state (3.10.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.10.2](https://github.com/mr-tanta/ndpr-toolkit/compare/v3.10.1...v3.10.2) (2026-05-25)
+
+README-only patch — runtime is byte-identical to 3.10.1. Fixes the npm-rendered README so it reflects the current state of the toolkit.
+
+### What was wrong
+
+The npm publish workflow runs `npm publish` from `working-directory: .` (the repo root), so the README that lands on the npm package page is **`/README.md`**, not `packages/ndpr-toolkit/README.md`. Three earlier releases (3.8.1, 3.9.0, 3.10.0) updated the inner README — wrong file — leaving the npm-visible header stuck at the v3.4.0 "What's new" notice with the v3.4.0 release link and the `1098 passing` tests badge.
+
+### What changed in this patch
+
+- "What's new" notice — v3.4.0 paragraph → consolidated 3.5 → 3.10.x highlights (NDPRThemeProvider, `/headless`, production DSR backend example, ecommerce starter, SSR-safe templates, Bun quickstart, typed DSR callbacks, Lite manager variants, focus management).
+- Header release link — `v3.4.0 Release` → `v3.10.1 Release`.
+- Tests badge — `1098 passing` → `1192 passing`.
+- StackBlitz / CodeSandbox "Open in" links — `examples/nextjs-app` (no longer exists) → `examples/ecommerce-starter`.
+- Screenshot image URLs — pinned tag `v3.5.2` → `v3.10.1` so the images come from the current release tree.
+
+The body of the README already had the correct content for everything below the header (Bun quickstart, Choose Your Layer, Adapters, Live Demos table, etc.).
+
 ## [3.10.1](https://github.com/mr-tanta/ndpr-toolkit/compare/v3.10.0...v3.10.1) (2026-05-25)
 
 Hotfix release. Code and runtime are identical to 3.10.0 — this patch fixes the build/publish pipeline that silently failed every release from 3.8.0 onward, so 3.10.1 is the first version since 3.7.0 to actually reach npm.

--- a/README.md
+++ b/README.md
@@ -6,20 +6,22 @@
 [![npm downloads](https://img.shields.io/npm/dm/@tantainnovative/ndpr-toolkit.svg)](https://www.npmjs.com/package/@tantainnovative/ndpr-toolkit)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5%2B-3178C6.svg)](https://www.typescriptlang.org/)
-[![Tests](https://img.shields.io/badge/tests-1098%20passing-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/tests-1192%20passing-brightgreen.svg)](#)
 [![Bundle Size](https://img.shields.io/bundlephobia/minzip/@tantainnovative/ndpr-toolkit)](https://bundlephobia.com/package/@tantainnovative/ndpr-toolkit)
 
 v3 ships **zero-config presets**, **pluggable storage adapters**, **compound components**, and a **compliance score engine** — eight production-ready modules covering consent, data subject rights, DPIA, breach notification, privacy policies, lawful basis, cross-border transfers, and ROPA.
 
-**[Documentation](https://ndprtoolkit.com.ng)** | **[Live Demos](https://ndprtoolkit.com.ng/ndpr-demos)** | **[npm](https://www.npmjs.com/package/@tantainnovative/ndpr-toolkit)** | **[Blog](https://ndprtoolkit.com.ng/blog)** | **[v3.4.0 Release](https://github.com/mr-tanta/ndpr-toolkit/releases/tag/v3.4.0)**
+**[Documentation](https://ndprtoolkit.com.ng)** | **[Live Demos](https://ndprtoolkit.com.ng/ndpr-demos)** | **[npm](https://www.npmjs.com/package/@tantainnovative/ndpr-toolkit)** | **[Blog](https://ndprtoolkit.com.ng/blog)** | **[v3.10.1 Release](https://github.com/mr-tanta/ndpr-toolkit/releases/tag/v3.10.1)**
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mr-tanta/ndpr-toolkit/tree/main/examples/nextjs-app)
-[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/github/mr-tanta/ndpr-toolkit/main/examples/nextjs-app)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/mr-tanta/ndpr-toolkit/tree/main/examples/ecommerce-starter)
+[![Open in CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/p/github/mr-tanta/ndpr-toolkit/main/examples/ecommerce-starter)
 
-> **What's new in 3.4.0:** components now ship styled defaults via a real stylesheet — Tailwind is no longer required. Add `import "@tantainnovative/ndpr-toolkit/styles";` once in your app entry. Plus a new `/server` subpath for RSC-safe pure-logic imports (validators, generators, scoring) with zero React in the import graph. Backward-compatible at the component API level. Full notes on the [release page](https://github.com/mr-tanta/ndpr-toolkit/releases/tag/v3.4.0).
+> **What's new in 3.10.x:** `NDPRThemeProvider` — a typed React Context that turns a JavaScript theme object into the `--ndpr-*` CSS variables the stylesheet already consumes. `/headless` subpath ships every hook with zero UI in the import graph (an alias of `/hooks` under a more discoverable name). A new production-grade DSR backend reference at `examples/dsr-backend-prod/` wires `NDPRSubjectRights` to Prisma persistence + Resend email confirmation behind dual-mode shims (no infra required to run). Three new docs guides: [theming](https://ndprtoolkit.com.ng/docs/guides/theming), [headless](https://ndprtoolkit.com.ng/docs/guides/headless), [production-dsr-backend](https://ndprtoolkit.com.ng/docs/guides/production-dsr-backend).
+>
+> **3.9.0** shipped runnable example apps — `examples/ecommerce-starter` (Nigerian multi-page storefront) and SSR-safe cookie-bridge templates for Next.js App Router, Remix, and Astro under `examples/ssr/*`. Plus Bun + Vite and Bun + Next.js quickstarts in this README. **3.8.1** added a typed `onSubmitSuccess` callback to `NDPRSubjectRights`, a documented DSR submission payload contract, accessibility notes, and a 3.5 → 3.8 migration guide. **3.8.0** shipped Lite (read-only) variants of the heavy Manager components (`/lawful-basis/lite`, `/cross-border/lite`, `/ropa/lite`). **3.6.0** added a typed `onSubmitError({ error, response })` callback. **3.5.x** added focus management (`useFocusTrap`), escape-to-dismiss, and `prefers-reduced-motion` support. Full notes on the [release page](https://github.com/mr-tanta/ndpr-toolkit/releases/tag/v3.10.1).
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/mr-tanta/ndpr-toolkit/v3.5.2/public/screenshots/hero.png" alt="NDPA Toolkit — NDPA Compliance Made Beautiful" width="800" />
+  <img src="https://raw.githubusercontent.com/mr-tanta/ndpr-toolkit/v3.10.1/public/screenshots/hero.png" alt="NDPA Toolkit — NDPA Compliance Made Beautiful" width="800" />
 </p>
 
 ---
@@ -68,7 +70,7 @@ import { apiAdapter } from '@tantainnovative/ndpr-toolkit/adapters';
 That's it. NDPA-compliant consent with server-side persistence in under 20 lines.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/mr-tanta/ndpr-toolkit/v3.5.2/public/screenshots/consent-demo.png" alt="Consent Management Demo — interactive consent banner with state inspector" width="800" />
+  <img src="https://raw.githubusercontent.com/mr-tanta/ndpr-toolkit/v3.10.1/public/screenshots/consent-demo.png" alt="Consent Management Demo — interactive consent banner with state inspector" width="800" />
   <br />
   <em>Interactive consent demo with configurable position, theme, storage, and real-time state inspector</em>
 </p>
@@ -432,13 +434,13 @@ Every module has an interactive demo. No signup, no setup — try them instantly
 
 <p align="center">
   <a href="https://ndprtoolkit.com.ng/ndpr-demos">
-    <img src="https://raw.githubusercontent.com/mr-tanta/ndpr-toolkit/v3.5.2/public/screenshots/demos-overview.png" alt="8 interactive live demos — zero setup required" width="800" />
+    <img src="https://raw.githubusercontent.com/mr-tanta/ndpr-toolkit/v3.10.1/public/screenshots/demos-overview.png" alt="8 interactive live demos — zero setup required" width="800" />
   </a>
 </p>
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/mr-tanta/ndpr-toolkit/v3.5.2/public/screenshots/dsr-demo.png" alt="Data Subject Rights — 8 rights with request tracking" width="400" />
-  <img src="https://raw.githubusercontent.com/mr-tanta/ndpr-toolkit/v3.5.2/public/screenshots/breach-demo.png" alt="Breach Notification — 72-hour countdown with step-by-step workflow" width="400" />
+  <img src="https://raw.githubusercontent.com/mr-tanta/ndpr-toolkit/v3.10.1/public/screenshots/dsr-demo.png" alt="Data Subject Rights — 8 rights with request tracking" width="400" />
+  <img src="https://raw.githubusercontent.com/mr-tanta/ndpr-toolkit/v3.10.1/public/screenshots/breach-demo.png" alt="Breach Notification — 72-hour countdown with step-by-step workflow" width="400" />
 </p>
 
 <p align="center">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tantainnovative/ndpr-toolkit",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "private": false,
   "description": "Nigeria Data Protection Toolkit — enterprise-grade compliance components for the Nigeria Data Protection Act (NDPA) 2023",
   "pnpm": {

--- a/packages/ndpr-toolkit/package.json
+++ b/packages/ndpr-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tantainnovative/ndpr-toolkit",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "React and TypeScript compliance components for the Nigeria Data Protection Act (NDPA) 2023",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary

README-only patch. Runtime is byte-identical to 3.10.1.

## What was wrong

The npm publish workflow runs \`npm publish\` from \`working-directory: .\` — the repo root — so the README that npm renders is **\`/README.md\`**, not \`packages/ndpr-toolkit/README.md\`.

I had this backwards. Three previous releases (3.8.1, 3.9.0, 3.10.0) updated the inner file by mistake. The npm-visible header was frozen at the v3.4.0 \"What's new\" notice / v3.4.0 Release link / 1098-passing tests badge while the actual code shipped through 3.10.1.

User flagged this directly. Verified by reading \`npm view @tantainnovative/ndpr-toolkit@3.10.1 readme\` instead of trusting the inner file.

## What changed

- \"What's new\" notice — v3.4.0 paragraph → consolidated 3.5 → 3.10.x highlights (\`NDPRThemeProvider\`, \`/headless\`, production DSR backend example, ecommerce starter, SSR templates, Bun quickstart, typed DSR callbacks, Lite manager variants, focus management)
- Header release link \`v3.4.0\` → \`v3.10.1\`
- Tests badge \`1098 passing\` → \`1192 passing\`
- \"Open in StackBlitz\" / CodeSandbox links \`examples/nextjs-app\` (deleted) → \`examples/ecommerce-starter\` (added in 3.9.0)
- Screenshot URLs tag pin \`v3.5.2\` → \`v3.10.1\`

The body of the README already had the correct content for everything below the header — only the version-tracked banner needed updating.

## Test plan

- [x] \`npm view @tantainnovative/ndpr-toolkit@3.10.1 readme\` confirms the bug
- [ ] After merge: \`npm view @tantainnovative/ndpr-toolkit@3.10.2 readme\` shows the new header