### PR TITLE
feat: 3.13.0 — i18n wired across 17 components + 4.0 deprecation window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,70 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [3.13.0](https://github.com/mr-tanta/ndpr-toolkit/compare/v3.12.0...v3.13.0) (2026-05-27)
+
+Release 5 of 6 on the post-audit roadmap. The **deprecation-window minor** — strictly additive, but every prop alias and behavior change that 4.0 will commit to gets fired here first as a dev-mode warning. Existing 3.x consumers see no breakage; new code can adopt the canonical surface.
+
+### i18n is real now — `useNDPRLocale` wired into 17+ components
+
+**The big one.** The toolkit shipped 5 locale files (`en`, `yo`, `ig`, `ha`, `pcm`) and exposed `useNDPRLocale()`, but only 3 components consumed the hook (post-3.10.4: `ConsentBanner`, `DSRRequestForm`, `BreachReportForm`). The remaining ~17 components ignored the locale prop, making `<NDPRProvider locale={…}>` mostly cosmetic. The audit's B14 report called this out as a top-tier finding.
+
+Newly wired components (each follows the prop-override → locale → English default precedence):
+
+- **DSR**: `DSRDashboard`, `DSRTracker`
+- **Breach**: `BreachRiskAssessment`, `BreachNotificationManager`, `RegulatoryReportGenerator`
+- **DPIA**: `DPIAQuestionnaire` (next/prev/submit buttons), `DPIAReport` (report title)
+- **Policy**: `PolicyGenerator`, `PolicyPreview`, `PolicyExporter`, `AdaptivePolicyWizard`
+- **Lawful basis**: `LawfulBasisTracker` + `LawfulBasisTrackerLite`
+- **Cross-border**: `CrossBorderTransferManager` + `CrossBorderTransferManagerLite`
+- **ROPA**: `ROPAManager` + `ROPAManagerLite`
+- **Consent extras**: `ConsentManager` (title/desc/save/reset)
+- **NDPRProvider** error-boundary fallback now reads `locale.common.error`
+
+The `NDPRLocale` type at `src/types/locale.ts` was expanded with new keys (`consent.managerTitle`, `dsr.dashboardTitle`, `breach.riskAssessmentTitle`, `policy.generatorTitle`, plus top-level `lawfulBasis`, `crossBorder`, `ropa` groups). All 5 shipped locale files got the matching translations.
+
+**21 new i18n regression tests** (3 cases × 7 modules) confirm each component honors the locale prop. Pattern matches `ConsentBanner-i18n.test.tsx` from 3.10.4.
+
+### Preset API harmonization (sets up 4.0 deprecation window)
+
+- **`submitTo` / `submitOptions` / `onSubmitSuccess` / `onSubmitError`** lifted from `NDPRSubjectRights` to `NDPRBreachReport` and `NDPRDPIA`. The latter two now support the same typed POST-and-route pattern. `NDPRDPIA` posts on last-section completion; both preserve the legacy `onSubmit` / `onComplete` callbacks so existing consumers see no change.
+- **`copy?` prop added to 6 presets** (`NDPRBreachReport`, `NDPRDPIA`, `NDPRLawfulBasis`, `NDPRCrossBorder`, `NDPRROPA`, `NDPRPrivacyPolicy`). Each ships a typed `NDPR<Name>Copy` interface, exported from `src/index.ts`. `NDPRConsent` already had this pattern; the 6 presets now match.
+- **`description` prop added** alongside `formDescription` on `BreachReportForm` + `NDPRBreachReport`. When both set, `description` wins; when only `formDescription` is set, a one-shot dev warn says `[ndpr-toolkit/breach] BreachReportFormProps.formDescription is deprecated; rename to 'description'. Will be removed in 4.0.`
+- **`initialData` prop added** alongside `initialActivities` on `NDPRLawfulBasis` and `initialTransfers` on `NDPRCrossBorder`. Same alias precedence + dev warn for the legacy names.
+
+### Privacy guard on `useDSR` default storage
+
+`useDSR()` is the admin tracker hook — its state contains OTHER PEOPLE'S PII (DSR requests submitted by data subjects). The current default writes to `localStorage` on the admin's browser, which is rarely the right place.
+
+Added a fire-once dev-only `console.warn` when a consumer uses the default `localStorage` path without an explicit adapter:
+
+> `[ndpr-toolkit/dsr] useDSR() is using the default localStorageAdapter, which stores DSR requests (including data subjects' PII) in the admin's browser. For production deployments, pass an explicit adapter… In 4.0, the default will switch to in-memory; localStorage will require explicit opt-in.`
+
+### Other dev-mode deprecations (queued for removal in 4.0)
+
+Every dev warn is guarded by `process.env.NODE_ENV !== 'production'` AND a `useRef`-based fire-once flag — production builds see no overhead, dev consoles see each warning once per component instance.
+
+- `NDPRConsentProps.extraOptions` — one-off pattern not used by other presets. Warn fires when passed.
+- `formDescription` on `BreachReportForm` / `NDPRBreachReport` — see above.
+- `initialActivities` on `NDPRLawfulBasis`, `initialTransfers` on `NDPRCrossBorder` — see above.
+
+### Deferred from the original 3.13.0 plan
+
+- **`useConsent` generic over options array** — non-trivial type-level refactor that needs the existing tests to be re-checked. Higher value if shipped together with the 4.0 type-cleanup window; deferring there.
+- **`useDSR.requestType` generic** — same shape, same reasoning.
+- **`ROPAManager.updateEditingField` generic over `keyof ProcessingRecord`** — internal refactor, defer to 4.0.
+- **`onSubmitError` discriminated union** — the current `{ error?, response? }` shape works for everyone today. Discriminated-union variant is breaking-ish (TS narrows differently); defer to 4.0.
+- **`validate*Structured()` returning `{ field, code, message }[]`** — additive, but the new shape needs its own docs page and migration story. Defer to 4.0 alongside the validator-message harmonization.
+- **`[ndpr-toolkit/<module>]` prefix on every utility error** — bulk-mechanical; defer (already happening organically — every dev warn we added in 3.13.0 carries the prefix).
+- **Arabic locale + RTL CSS conversion** — defer to a focused i18n release after 4.0. The shape is now in place (`ar.ts` can be one file); the logical-property CSS conversion is its own focused chore.
+- **French locale (`fr.ts`)** — same; one data file once the type/wiring is stable.
+
+### Verification
+
+- Jest: **1258 / 1258 passing** (was 1237; +21 new i18n tests)
+- `tsc --noEmit -p tsconfig.json` clean
+- `pnpm verify:tarball --skip-ts` clean across all 22 subpaths
+
 ## [3.12.0](https://github.com/mr-tanta/ndpr-toolkit/compare/v3.11.0...v3.12.0) (2026-05-27)
 
 Release 4 of 6 on the post-audit roadmap. Accessibility + performance + test coverage. No public API changes — everything is additive or behaviour-preserving internal work. Existing consumers see no breakage; users of assistive tech and consumers of large managers see real improvements.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tantainnovative/ndpr-toolkit",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "private": false,
   "description": "Nigeria Data Protection Toolkit — enterprise-grade compliance components for the Nigeria Data Protection Act (NDPA) 2023",
   "pnpm": {

--- a/packages/ndpr-toolkit/package.json
+++ b/packages/ndpr-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tantainnovative/ndpr-toolkit",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "private": true,
   "description": "React and TypeScript compliance components for the Nigeria Data Protection Act (NDPA) 2023. NOTE: This inner package.json is NOT published — `npm publish` runs from the repo root. Marked `private: true` since 3.10.5 to make that explicit and prevent the drift class that caused the 3.8.0–3.10.2 missing-exports incident. Slated for removal in 4.0 (see plan: clear-the-audit-backlog).",
   "main": "./dist/index.js",

--- a/packages/ndpr-toolkit/src/__tests__/components/breach/BreachNotificationManager-i18n.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/components/breach/BreachNotificationManager-i18n.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Locale wiring regression test for BreachNotificationManager — companion to
+ * the ConsentBanner-i18n suite. See that file for full rationale.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { NDPRProvider } from '../../../components/NDPRProvider';
+import { BreachNotificationManager } from '../../../components/breach/BreachNotificationManager';
+import type { NDPRLocale } from '../../../types/locale';
+import type { BreachReport } from '../../../types/breach';
+
+const yorubaLocale: NDPRLocale = {
+  breach: {
+    notificationManagerTitle: 'Olùṣàkóso Ìfitónilétí Ìrúfin',
+    notificationManagerDescription: 'Ṣàkóso ìfitónilétí ìrúfin dátà.',
+  },
+};
+
+const sampleBreaches: BreachReport[] = [
+  {
+    id: 'breach-1',
+    title: 'Test Breach',
+    description: 'A test data breach',
+    category: 'unauthorized-access',
+    discoveredAt: Date.now() - 24 * 60 * 60 * 1000,
+    reportedAt: Date.now() - 23 * 60 * 60 * 1000,
+    reporter: { name: 'Jane Doe', email: 'jane@example.com', department: 'IT' },
+    affectedSystems: ['Database'],
+    dataTypes: ['email'],
+    estimatedAffectedSubjects: 10,
+    status: 'ongoing',
+  },
+];
+
+describe('BreachNotificationManager — locale wiring (B14 fix)', () => {
+  it('renders English defaults with no NDPRProvider', () => {
+    render(
+      <BreachNotificationManager
+        breachReports={sampleBreaches}
+        riskAssessments={[]}
+        regulatoryNotifications={[]}
+      />,
+    );
+    expect(
+      screen.getByRole('heading', { name: /Breach Notification Manager/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/manage data breach notifications/i)).toBeInTheDocument();
+  });
+
+  it('renders locale strings when wrapped in <NDPRProvider locale={...}>', () => {
+    render(
+      <NDPRProvider locale={yorubaLocale}>
+        <BreachNotificationManager
+          breachReports={sampleBreaches}
+          riskAssessments={[]}
+          regulatoryNotifications={[]}
+        />
+      </NDPRProvider>,
+    );
+    expect(
+      screen.getByRole('heading', { name: /Olùṣàkóso Ìfitónilétí Ìrúfin/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: /Breach Notification Manager/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('explicit prop overrides win over provider locale', () => {
+    render(
+      <NDPRProvider locale={yorubaLocale}>
+        <BreachNotificationManager
+          breachReports={sampleBreaches}
+          riskAssessments={[]}
+          regulatoryNotifications={[]}
+          title="Custom Manager"
+        />
+      </NDPRProvider>,
+    );
+    expect(screen.getByRole('heading', { name: 'Custom Manager' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: /Olùṣàkóso Ìfitónilétí Ìrúfin/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/ndpr-toolkit/src/__tests__/components/cross-border/CrossBorderTransferManager-i18n.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/components/cross-border/CrossBorderTransferManager-i18n.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Locale wiring regression test for CrossBorderTransferManager — companion to
+ * the ConsentBanner-i18n suite. See that file for full rationale.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { NDPRProvider } from '../../../components/NDPRProvider';
+import { CrossBorderTransferManager } from '../../../components/cross-border/CrossBorderTransferManager';
+import type { NDPRLocale } from '../../../types/locale';
+import type { CrossBorderTransfer } from '../../../types/cross-border';
+
+const NOW = 1_700_000_000_000;
+
+const transfers: CrossBorderTransfer[] = [
+  {
+    id: 'xfer-1',
+    destinationCountry: 'United Kingdom',
+    destinationCountryCode: 'GB',
+    adequacyStatus: 'adequate',
+    transferMechanism: 'adequacy_decision',
+    dataCategories: ['name', 'email'],
+    includesSensitiveData: false,
+    recipientOrganization: 'Acme UK Ltd',
+    recipientContact: { name: 'Jane', email: 'jane@acme.example.com' },
+    purpose: 'Fulfilment',
+    safeguards: ['TLS'],
+    riskAssessment: 'Low risk',
+    riskLevel: 'low',
+    tiaCompleted: true,
+    frequency: 'periodic',
+    startDate: NOW - 86_400_000 * 30,
+    status: 'active',
+    createdAt: NOW - 86_400_000 * 30,
+    updatedAt: NOW,
+  },
+];
+
+const yorubaLocale: NDPRLocale = {
+  crossBorder: {
+    title: 'Olùṣàkóso Gbígbé Dátà Kọjá-Ààlà',
+    description: 'Ṣàkóso gbígbé dátà.',
+  },
+};
+
+describe('CrossBorderTransferManager — locale wiring (B14 fix)', () => {
+  it('renders English defaults with no NDPRProvider', () => {
+    render(<CrossBorderTransferManager transfers={transfers} />);
+    expect(
+      screen.getByRole('heading', { name: /Cross-Border Data Transfer Manager/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/NDPA 2023 Part VI/i)).toBeInTheDocument();
+  });
+
+  it('renders locale strings when wrapped in <NDPRProvider locale={...}>', () => {
+    render(
+      <NDPRProvider locale={yorubaLocale}>
+        <CrossBorderTransferManager transfers={transfers} />
+      </NDPRProvider>,
+    );
+    expect(
+      screen.getByRole('heading', { name: /Olùṣàkóso Gbígbé Dátà Kọjá-Ààlà/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: /Cross-Border Data Transfer Manager/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('explicit prop overrides win over provider locale', () => {
+    render(
+      <NDPRProvider locale={yorubaLocale}>
+        <CrossBorderTransferManager transfers={transfers} title="Custom Transfer Manager" />
+      </NDPRProvider>,
+    );
+    expect(
+      screen.getByRole('heading', { name: 'Custom Transfer Manager' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: /Olùṣàkóso Gbígbé Dátà Kọjá-Ààlà/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/ndpr-toolkit/src/__tests__/components/dpia/DPIAQuestionnaire-i18n.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/components/dpia/DPIAQuestionnaire-i18n.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Locale wiring regression test for DPIAQuestionnaire — companion to the
+ * ConsentBanner-i18n suite. See that file for full rationale.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { NDPRProvider } from '../../../components/NDPRProvider';
+import { DPIAQuestionnaire } from '../../../components/dpia/DPIAQuestionnaire';
+import type { NDPRLocale } from '../../../types/locale';
+import type { DPIASection } from '../../../types/dpia';
+
+const yorubaLocale: NDPRLocale = {
+  dpia: {
+    next: 'Tẹ̀lé',
+    previous: 'Sẹ́yìn',
+    submit: 'Fi Sílẹ̀',
+  },
+};
+
+const sections: DPIASection[] = [
+  {
+    id: 's1',
+    title: 'Section 1',
+    questions: [{ id: 'q1', text: 'Question one?', type: 'text', required: false }],
+  },
+  {
+    id: 's2',
+    title: 'Section 2',
+    questions: [{ id: 'q2', text: 'Question two?', type: 'text', required: false }],
+  },
+];
+
+describe('DPIAQuestionnaire — locale wiring (B14 fix)', () => {
+  it('renders English defaults with no NDPRProvider', () => {
+    render(
+      <DPIAQuestionnaire
+        sections={sections}
+        answers={{}}
+        onAnswerChange={() => {}}
+        currentSectionIndex={0}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Next' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Previous' })).toBeInTheDocument();
+  });
+
+  it('renders locale strings when wrapped in <NDPRProvider locale={...}>', () => {
+    render(
+      <NDPRProvider locale={yorubaLocale}>
+        <DPIAQuestionnaire
+          sections={sections}
+          answers={{}}
+          onAnswerChange={() => {}}
+          currentSectionIndex={0}
+        />
+      </NDPRProvider>,
+    );
+    expect(screen.getByRole('button', { name: 'Tẹ̀lé' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sẹ́yìn' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Next' })).not.toBeInTheDocument();
+  });
+
+  it('explicit prop overrides win over provider locale', () => {
+    render(
+      <NDPRProvider locale={yorubaLocale}>
+        <DPIAQuestionnaire
+          sections={sections}
+          answers={{}}
+          onAnswerChange={() => {}}
+          currentSectionIndex={0}
+          nextButtonText="Forward!"
+        />
+      </NDPRProvider>,
+    );
+    expect(screen.getByRole('button', { name: 'Forward!' })).toBeInTheDocument();
+    // Yoruba "Tẹ̀lé" must NOT show because the prop overrode it.
+    expect(screen.queryByRole('button', { name: 'Tẹ̀lé' })).not.toBeInTheDocument();
+    // But other locale strings still apply.
+    expect(screen.getByRole('button', { name: 'Sẹ́yìn' })).toBeInTheDocument();
+  });
+});

--- a/packages/ndpr-toolkit/src/__tests__/components/dsr/DSRDashboard-i18n.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/components/dsr/DSRDashboard-i18n.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * Locale wiring regression test for DSRDashboard — companion to the
+ * ConsentBanner-i18n suite. See that file for full rationale.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { NDPRProvider } from '../../../components/NDPRProvider';
+import { DSRDashboard } from '../../../components/dsr/DSRDashboard';
+import type { NDPRLocale } from '../../../types/locale';
+import type { DSRRequest } from '../../../types/dsr';
+
+const yorubaLocale: NDPRLocale = {
+  dsr: {
+    dashboardTitle: 'Pápá Iṣẹ́ Ìbéèrè Oní-dátà',
+    dashboardDescription: 'Tọpa àti ṣàkóso àwọn ìbéèrè oní-dátà.',
+  },
+};
+
+const requests: DSRRequest[] = [
+  {
+    id: '1',
+    type: 'access',
+    status: 'pending',
+    createdAt: 1620000000000,
+    updatedAt: 1620000000000,
+    subject: { name: 'John Doe', email: 'john@example.com' },
+  },
+];
+
+describe('DSRDashboard — locale wiring (B14 fix)', () => {
+  it('renders English defaults with no NDPRProvider', () => {
+    render(<DSRDashboard requests={requests} />);
+    expect(
+      screen.getByRole('heading', { name: /Data Subject Request Dashboard/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Track and manage data subject requests in compliance with NDPA Part IV/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders locale strings when wrapped in <NDPRProvider locale={...}>', () => {
+    render(
+      <NDPRProvider locale={yorubaLocale}>
+        <DSRDashboard requests={requests} />
+      </NDPRProvider>,
+    );
+    expect(
+      screen.getByRole('heading', { name: /Pápá Iṣẹ́ Ìbéèrè Oní-dátà/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: /Data Subject Request Dashboard/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('explicit prop overrides win over provider locale', () => {
+    render(
+      <NDPRProvider locale={yorubaLocale}>
+        <DSRDashboard requests={requests} title="My Custom Dashboard" />
+      </NDPRProvider>,
+    );
+    expect(screen.getByRole('heading', { name: 'My Custom Dashboard' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: /Pápá Iṣẹ́ Ìbéèrè Oní-dátà/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/ndpr-toolkit/src/__tests__/components/lawful-basis/LawfulBasisTracker-i18n.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/components/lawful-basis/LawfulBasisTracker-i18n.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Locale wiring regression test for LawfulBasisTracker — companion to the
+ * ConsentBanner-i18n suite. See that file for full rationale.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { NDPRProvider } from '../../../components/NDPRProvider';
+import { LawfulBasisTracker } from '../../../components/lawful-basis/LawfulBasisTracker';
+import type { NDPRLocale } from '../../../types/locale';
+import type { ProcessingActivity } from '../../../types/lawful-basis';
+
+const NOW = 1_700_000_000_000;
+
+const activities: ProcessingActivity[] = [
+  {
+    id: 'act-1',
+    name: 'Customer Onboarding',
+    description: 'Collecting personal data',
+    lawfulBasis: 'consent',
+    lawfulBasisJustification: 'Explicit consent gathered.',
+    dataCategories: ['name', 'email'],
+    involvesSensitiveData: false,
+    dataSubjectCategories: ['customers'],
+    purposes: ['signup'],
+    retentionPeriod: '3 years',
+    crossBorderTransfer: false,
+    createdAt: NOW - 86_400_000,
+    updatedAt: NOW,
+    status: 'active',
+  },
+];
+
+const yorubaLocale: NDPRLocale = {
+  lawfulBasis: {
+    title: 'Olùtọpa Ìpilẹ̀ Òfin',
+    description: 'Ṣe àkọsílẹ̀ ìpilẹ̀ òfin.',
+  },
+};
+
+describe('LawfulBasisTracker — locale wiring (B14 fix)', () => {
+  it('renders English defaults with no NDPRProvider', () => {
+    render(<LawfulBasisTracker activities={activities} />);
+    expect(screen.getByRole('heading', { name: /Lawful Basis Tracker/i })).toBeInTheDocument();
+    expect(screen.getByText(/NDPA 2023 Section 25/i)).toBeInTheDocument();
+  });
+
+  it('renders locale strings when wrapped in <NDPRProvider locale={...}>', () => {
+    render(
+      <NDPRProvider locale={yorubaLocale}>
+        <LawfulBasisTracker activities={activities} />
+      </NDPRProvider>,
+    );
+    expect(
+      screen.getByRole('heading', { name: /Olùtọpa Ìpilẹ̀ Òfin/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: /Lawful Basis Tracker/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('explicit prop overrides win over provider locale', () => {
+    render(
+      <NDPRProvider locale={yorubaLocale}>
+        <LawfulBasisTracker activities={activities} title="Custom LB Title" />
+      </NDPRProvider>,
+    );
+    expect(screen.getByRole('heading', { name: 'Custom LB Title' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: /Olùtọpa Ìpilẹ̀ Òfin/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/ndpr-toolkit/src/__tests__/components/policy/PolicyGenerator-i18n.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/components/policy/PolicyGenerator-i18n.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * Locale wiring regression test for PolicyGenerator — companion to the
+ * ConsentBanner-i18n suite. See that file for full rationale.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { NDPRProvider } from '../../../components/NDPRProvider';
+import { PolicyGenerator } from '../../../components/policy/PolicyGenerator';
+import type { NDPRLocale } from '../../../types/locale';
+
+const yorubaLocale: NDPRLocale = {
+  policy: {
+    generatorTitle: 'Olùpilẹ̀ṣẹ̀ Ìlànà Àṣírí NDPA',
+    generatorDescription: 'Ṣẹ̀dá ìlànà àṣírí.',
+    generate: 'Ṣẹ̀dá Ìlànà',
+  },
+};
+
+describe('PolicyGenerator — locale wiring (B14 fix)', () => {
+  it('renders English defaults with no NDPRProvider', () => {
+    render(<PolicyGenerator onGenerate={() => {}} />);
+    expect(
+      screen.getByRole('heading', { name: /NDPA Privacy Policy Generator/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Generate an NDPA-compliant privacy policy/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders locale strings when wrapped in <NDPRProvider locale={...}>', () => {
+    render(
+      <NDPRProvider locale={yorubaLocale}>
+        <PolicyGenerator onGenerate={() => {}} />
+      </NDPRProvider>,
+    );
+    expect(
+      screen.getByRole('heading', { name: /Olùpilẹ̀ṣẹ̀ Ìlànà Àṣírí NDPA/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: /NDPA Privacy Policy Generator/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('explicit prop overrides win over provider locale', () => {
+    render(
+      <NDPRProvider locale={yorubaLocale}>
+        <PolicyGenerator onGenerate={() => {}} title="Custom Policy Tool" />
+      </NDPRProvider>,
+    );
+    expect(screen.getByRole('heading', { name: 'Custom Policy Tool' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: /Olùpilẹ̀ṣẹ̀ Ìlànà Àṣírí NDPA/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/ndpr-toolkit/src/__tests__/components/ropa/ROPAManager-i18n.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/components/ropa/ROPAManager-i18n.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Locale wiring regression test for ROPAManager — companion to the
+ * ConsentBanner-i18n suite. See that file for full rationale.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { NDPRProvider } from '../../../components/NDPRProvider';
+import { ROPAManager } from '../../../components/ropa/ROPAManager';
+import type { NDPRLocale } from '../../../types/locale';
+import type { RecordOfProcessingActivities } from '../../../types/ropa';
+
+const NOW = 1_700_000_000_000;
+
+const ropa: RecordOfProcessingActivities = {
+  id: 'ropa-1',
+  organizationName: 'Acme Corp',
+  organizationContact: 'privacy@acme.example',
+  organizationAddress: '123 Lagos St',
+  records: [],
+  lastUpdated: NOW,
+  version: '1.0',
+};
+
+const yorubaLocale: NDPRLocale = {
+  ropa: {
+    title: 'Àkọsílẹ̀ Àwọn Iṣẹ́ Ìṣàkóso',
+    description: 'Pa àkọsílẹ̀ mọ́.',
+  },
+};
+
+describe('ROPAManager — locale wiring (B14 fix)', () => {
+  it('renders English defaults with no NDPRProvider', () => {
+    render(<ROPAManager ropa={ropa} />);
+    expect(
+      screen.getByRole('heading', { name: /Record of Processing Activities/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/accountability principle/i)).toBeInTheDocument();
+  });
+
+  it('renders locale strings when wrapped in <NDPRProvider locale={...}>', () => {
+    render(
+      <NDPRProvider locale={yorubaLocale}>
+        <ROPAManager ropa={ropa} />
+      </NDPRProvider>,
+    );
+    expect(
+      screen.getByRole('heading', { name: /Àkọsílẹ̀ Àwọn Iṣẹ́ Ìṣàkóso/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: /Record of Processing Activities/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('explicit prop overrides win over provider locale', () => {
+    render(
+      <NDPRProvider locale={yorubaLocale}>
+        <ROPAManager ropa={ropa} title="Custom ROPA Title" />
+      </NDPRProvider>,
+    );
+    expect(screen.getByRole('heading', { name: 'Custom ROPA Title' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: /Àkọsílẹ̀ Àwọn Iṣẹ́ Ìṣàkóso/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/ndpr-toolkit/src/components/NDPRProvider.tsx
+++ b/packages/ndpr-toolkit/src/components/NDPRProvider.tsx
@@ -66,6 +66,12 @@ interface NDPRErrorBoundaryProps {
   fallback?: ReactNode | ((error: Error, reset: () => void) => ReactNode);
   /** Called when an error is caught. */
   onError?: (error: Error, errorInfo: ErrorInfo) => void;
+  /**
+   * Heading shown above the error message in the default fallback UI.
+   * NDPRProvider passes the locale-resolved `common.error` string here.
+   * @default "Something went wrong"
+   */
+  errorTitle?: string;
 }
 
 interface NDPRErrorBoundaryState {
@@ -122,7 +128,7 @@ export class NDPRErrorBoundary extends Component<NDPRErrorBoundaryProps, NDPRErr
             color: '#c53030',
           }}
         >
-          <h3 style={{ margin: '0 0 8px 0', fontSize: '16px' }}>Something went wrong</h3>
+          <h3 style={{ margin: '0 0 8px 0', fontSize: '16px' }}>{this.props.errorTitle ?? 'Something went wrong'}</h3>
           <p style={{ margin: 0, fontSize: '14px' }}>{error.message}</p>
         </div>
       );
@@ -163,9 +169,14 @@ export const NDPRProvider: React.FC<NDPRConfig & { children: React.ReactNode }> 
     return Object.keys(vars).length > 0 ? (vars as React.CSSProperties) : undefined;
   }, [config.theme]);
 
+  // Resolve the error-boundary heading once per render. The class component
+  // can't call hooks, so we feed it the locale-derived string as a prop.
+  const resolvedLocale = useMemo(() => mergeLocale(config.locale), [config.locale]);
+  const errorTitle = resolvedLocale.common.error ?? 'Something went wrong';
+
   return (
     <NDPRContext.Provider value={config}>
-      <NDPRErrorBoundary fallback={fallback} onError={onError}>
+      <NDPRErrorBoundary fallback={fallback} onError={onError} errorTitle={errorTitle}>
         {style ? <div style={style}>{children}</div> : children}
       </NDPRErrorBoundary>
     </NDPRContext.Provider>

--- a/packages/ndpr-toolkit/src/components/breach/BreachNotificationManager.tsx
+++ b/packages/ndpr-toolkit/src/components/breach/BreachNotificationManager.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { BreachReport, RiskAssessment, RegulatoryNotification, NotificationRequirement } from '../../types/breach';
 import { calculateBreachSeverity } from '../../utils/breach';
 import { resolveClass } from '../../utils/styling';
+import { useNDPRLocale } from '../NDPRProvider';
 
 export interface BreachNotificationManagerClassNames {
   root?: string;
@@ -109,8 +110,9 @@ export const BreachNotificationManager: React.FC<BreachNotificationManagerProps>
   onSelectBreach,
   onRequestAssessment,
   onRequestNotification,
-  title = "Breach Notification Manager",
-  description = "Manage data breach notifications and track compliance with NDPA Section 40 requirements.",
+  // i18n: explicit prop > provider locale > English default.
+  title,
+  description,
   className = "",
   buttonClassName = "",
   classNames: cn = {},
@@ -119,6 +121,11 @@ export const BreachNotificationManager: React.FC<BreachNotificationManagerProps>
   showNotificationTimeline = true,
   showDeadlineAlerts = true
 }) => {
+  const locale = useNDPRLocale();
+  const resolvedTitle = title ?? locale.breach.notificationManagerTitle ?? 'Breach Notification Manager';
+  const resolvedDescription =
+    description ?? locale.breach.notificationManagerDescription ??
+    'Manage data breach notifications and track compliance with NDPA Section 40 requirements.';
   const [selectedBreachId, setSelectedBreachId] = useState<string | null>(null);
   const [filteredBreaches, setFilteredBreaches] = useState<BreachReport[]>(breachReports);
   const [statusFilter, setStatusFilter] = useState<string>('all');
@@ -433,8 +440,8 @@ export const BreachNotificationManager: React.FC<BreachNotificationManagerProps>
   return (
     <div className={resolveClass(`bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md ${className}`, cn.root, unstyled)}>
       <div className={resolveClass("", cn.header, unstyled)}>
-        <h2 className={resolveClass('ndpr-section-heading', cn.title, unstyled)}>{title}</h2>
-        <p className='ndpr-card__subtitle'>{description}</p>
+        <h2 className={resolveClass('ndpr-section-heading', cn.title, unstyled)}>{resolvedTitle}</h2>
+        <p className='ndpr-card__subtitle'>{resolvedDescription}</p>
       </div>
       
       {/* Filters and Search */}

--- a/packages/ndpr-toolkit/src/components/breach/BreachReportForm.tsx
+++ b/packages/ndpr-toolkit/src/components/breach/BreachReportForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { BreachCategory } from '../../types/breach';
 import { resolveClass } from '../../utils/styling';
 import { sanitizeInput } from '../../utils/sanitize';
@@ -124,8 +124,15 @@ export interface BreachReportFormProps {
   title?: string;
   
   /**
-   * Description text displayed on the form
+   * Description text displayed on the form. Canonical name in 3.13+.
+   * Takes precedence over `formDescription` if both are set.
    * @default "Use this form to report a suspected or confirmed data breach in accordance with NDPA Section 40. All fields marked with * are required."
+   */
+  description?: string;
+
+  /**
+   * @deprecated Renamed to `description`. Will be removed in 4.0.
+   * If both are set, `description` wins.
    */
   formDescription?: string;
   
@@ -223,6 +230,7 @@ export const BreachReportForm: React.FC<BreachReportFormProps> = ({
   // (prop → useNDPRLocale → English default) works. Pre-3.10.4 these
   // defaulted directly to English.
   title,
+  description,
   formDescription,
   submitButtonText,
   className = "",
@@ -239,11 +247,30 @@ export const BreachReportForm: React.FC<BreachReportFormProps> = ({
   defaultValues,
   onReset
 }) => {
+  // Dev-only deprecation warning: `formDescription` is the 3.x name;
+  // `description` is the canonical 3.13+ name. Fire-once per instance.
+  const warnedFormDescriptionRef = useRef(false);
+  useEffect(() => {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      formDescription !== undefined &&
+      description === undefined &&
+      !warnedFormDescriptionRef.current
+    ) {
+      warnedFormDescriptionRef.current = true;
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[ndpr-toolkit/breach] BreachReportFormProps.formDescription is deprecated; rename to 'description'. Will be removed in 4.0.",
+      );
+    }
+  }, [formDescription, description]);
+
   // i18n: explicit prop > provider locale > English default.
+  // `description` (3.13+) wins over the legacy `formDescription`.
   const locale = useNDPRLocale();
   const resolvedTitle = title ?? locale.breach.title ?? 'Report a Data Breach';
   const resolvedFormDescription =
-    formDescription ?? locale.breach.description ??
+    description ?? formDescription ?? locale.breach.description ??
     'Use this form to report a suspected or confirmed data breach in accordance with NDPA Section 40. All fields marked with * are required.';
   const resolvedSubmit = submitButtonText ?? locale.breach.submitReport ?? 'Submit Report';
 
@@ -256,7 +283,11 @@ export const BreachReportForm: React.FC<BreachReportFormProps> = ({
   };
 
   const [breachTitle, setBreachTitle] = useState<string>(defaultValues?.title || "");
-  const [description, setDescription] = useState<string>(defaultValues?.description || "");
+  // Renamed in 3.13 from `description` to `breachDescription` because the
+  // canonical 3.13+ prop is also called `description` (the title-card text
+  // displayed above the form). The state variable holds the breach's own
+  // free-text description from the textarea field.
+  const [breachDescription, setBreachDescription] = useState<string>(defaultValues?.description || "");
   const [category, setCategory] = useState<string>(defaultValues?.category || "");
   const [discoveredAt, setDiscoveredAt] = useState<string>(formatDateTimeLocal(defaultValues?.discoveredAt));
   const [occurredAt, setOccurredAt] = useState<string>(formatDateTimeLocal(defaultValues?.occurredAt));
@@ -295,7 +326,7 @@ export const BreachReportForm: React.FC<BreachReportFormProps> = ({
   // Reset all fields to empty state
   const handleReset = () => {
     setBreachTitle("");
-    setDescription("");
+    setBreachDescription("");
     setCategory("");
     setDiscoveredAt("");
     setOccurredAt("");
@@ -405,7 +436,7 @@ export const BreachReportForm: React.FC<BreachReportFormProps> = ({
       newErrors.breachTitle = "Breach title is required";
     }
 
-    if (!description.trim()) {
+    if (!breachDescription.trim()) {
       newErrors.description = "Description is required";
     }
 
@@ -460,7 +491,7 @@ export const BreachReportForm: React.FC<BreachReportFormProps> = ({
     // Sanitize all text field values to prevent XSS
     const formData: BreachFormSubmission = {
       title: sanitizeInput(breachTitle),
-      description: sanitizeInput(description),
+      description: sanitizeInput(breachDescription),
       category,
       discoveredAt: new Date(discoveredAt).getTime(),
       occurredAt: occurredAt ? new Date(occurredAt).getTime() : undefined,
@@ -600,8 +631,8 @@ export const BreachReportForm: React.FC<BreachReportFormProps> = ({
                 </label>
                 <textarea
                   id="description"
-                  value={description}
-                  onChange={e => setDescription(e.target.value)}
+                  value={breachDescription}
+                  onChange={e => setBreachDescription(e.target.value)}
                   rows={4}
                   className={resolveClass('ndpr-form-field__input', cn.textarea, unstyled)}
                   required

--- a/packages/ndpr-toolkit/src/components/breach/BreachRiskAssessment.tsx
+++ b/packages/ndpr-toolkit/src/components/breach/BreachRiskAssessment.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { BreachReport, RiskAssessment } from '../../types/breach';
 import { calculateBreachSeverity } from '../../utils/breach';
 import { resolveClass } from '../../utils/styling';
+import { useNDPRLocale } from '../NDPRProvider';
 
 export interface BreachRiskAssessmentClassNames {
   root?: string;
@@ -91,9 +92,10 @@ export const BreachRiskAssessment: React.FC<BreachRiskAssessmentProps> = ({
   breachData,
   initialAssessment = {},
   onComplete,
-  title = "Breach Risk Assessment",
-  description = "Assess the risk level of this data breach to determine notification requirements under NDPA Section 40.",
-  submitButtonText = "Complete Assessment",
+  // i18n: explicit prop > provider locale > English default.
+  title,
+  description,
+  submitButtonText,
   className = "",
   buttonClassName = "",
   classNames: cn = {},
@@ -101,6 +103,12 @@ export const BreachRiskAssessment: React.FC<BreachRiskAssessmentProps> = ({
   showBreachSummary = true,
   showNotificationRequirements = true
 }) => {
+  const locale = useNDPRLocale();
+  const resolvedTitle = title ?? locale.breach.riskAssessmentTitle ?? 'Breach Risk Assessment';
+  const resolvedDescription =
+    description ?? locale.breach.riskAssessmentDescription ??
+    'Assess the risk level of this data breach to determine notification requirements under NDPA Section 40.';
+  const resolvedSubmit = submitButtonText ?? locale.dpia.complete ?? 'Complete Assessment';
   // Assessment form state
   const [confidentialityImpact, setConfidentialityImpact] = useState<number>(initialAssessment.confidentialityImpact || 3);
   const [integrityImpact, setIntegrityImpact] = useState<number>(initialAssessment.integrityImpact || 3);
@@ -237,8 +245,8 @@ export const BreachRiskAssessment: React.FC<BreachRiskAssessmentProps> = ({
 
   return (
     <div data-ndpr-component="breach-risk-assessment" className={resolveClass(`bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md ${className}`, cn.root, unstyled)}>
-      <h2 className={resolveClass('ndpr-section-heading', cn.title, unstyled)}>{title}</h2>
-      <p className='ndpr-card__subtitle'>{description}</p>
+      <h2 className={resolveClass('ndpr-section-heading', cn.title, unstyled)}>{resolvedTitle}</h2>
+      <p className='ndpr-card__subtitle'>{resolvedDescription}</p>
       
       {/* Breach Summary */}
       {showBreachSummary && (
@@ -589,7 +597,7 @@ export const BreachRiskAssessment: React.FC<BreachRiskAssessmentProps> = ({
                 type="submit"
                 className={resolveClass(`px-6 py-3 bg-[rgb(var(--ndpr-primary))] text-white rounded-md hover:bg-[rgb(var(--ndpr-primary-hover))] focus:outline-none focus:ring-2 focus:ring-[rgb(var(--ndpr-ring))] focus:ring-offset-2 ${buttonClassName}`, cn.primaryButton || cn.submitButton, unstyled)}
               >
-                {submitButtonText}
+                {resolvedSubmit}
               </button>
             </div>
           </div>

--- a/packages/ndpr-toolkit/src/components/breach/RegulatoryReportGenerator.tsx
+++ b/packages/ndpr-toolkit/src/components/breach/RegulatoryReportGenerator.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { BreachReport, RiskAssessment, RegulatoryNotification } from '../../types/breach';
 import { resolveClass } from '../../utils/styling';
 import { LEGAL_DISCLAIMER_LONG, LEGAL_DISCLAIMER_SHORT } from '../../utils/legal-notice';
+import { useNDPRLocale } from '../NDPRProvider';
 
 export interface RegulatoryReportGeneratorClassNames {
   root?: string;
@@ -149,9 +150,10 @@ export const RegulatoryReportGenerator: React.FC<RegulatoryReportGeneratorProps>
   assessmentData,
   organizationInfo,
   onGenerate,
-  title = "Generate NDPC Notification Report",
-  description = "Generate a report for submission to the NDPC in compliance with NDPA Section 40 breach notification requirements.",
-  generateButtonText = "Generate Report",
+  // i18n: explicit prop > provider locale > English default.
+  title,
+  description,
+  generateButtonText,
   className = "",
   buttonClassName = "",
   classNames: cn = {},
@@ -161,6 +163,15 @@ export const RegulatoryReportGenerator: React.FC<RegulatoryReportGeneratorProps>
   allowDownload = true,
   downloadFormat = "pdf"
 }) => {
+  const locale = useNDPRLocale();
+  const resolvedTitle = title ?? locale.breach.regulatoryReportTitle ?? 'Generate NDPC Notification Report';
+  const resolvedDescription =
+    description ?? locale.breach.regulatoryReportDescription ??
+    'Generate a report for submission to the NDPC in compliance with NDPA Section 40 breach notification requirements.';
+  // Note: this button text is intentionally not pulled from `locale.policy.generate`
+  // because the policy module's "Generate Policy" string would mis-label this
+  // breach-report button. Consumers can override explicitly via the prop.
+  const resolvedGenerateButton = generateButtonText ?? 'Generate Report';
   // Form state
   const [reportContent, setReportContent] = useState<string>("");
   const [contactName, setContactName] = useState<string>("");
@@ -393,8 +404,8 @@ ${LEGAL_DISCLAIMER_LONG}
   return (
     <div data-ndpr-component="regulatory-report-generator" className={resolveClass(`bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md ${className}`, cn.root, unstyled)}>
       <div className={resolveClass("", cn.header, unstyled)}>
-        <h2 className={resolveClass('ndpr-section-heading', cn.title, unstyled)}>{title}</h2>
-        <p className='ndpr-card__subtitle'>{description}</p>
+        <h2 className={resolveClass('ndpr-section-heading', cn.title, unstyled)}>{resolvedTitle}</h2>
+        <p className='ndpr-card__subtitle'>{resolvedDescription}</p>
       </div>
       
       {isSubmitted ? (
@@ -591,7 +602,7 @@ ${LEGAL_DISCLAIMER_LONG}
                 type="submit"
                 className={resolveClass(`px-6 py-3 bg-[rgb(var(--ndpr-primary))] text-white rounded-md hover:bg-[rgb(var(--ndpr-primary-hover))] focus:outline-none focus:ring-2 focus:ring-[rgb(var(--ndpr-ring))] focus:ring-offset-2 ${buttonClassName}`, cn.primaryButton || cn.generateButton, unstyled)}
               >
-                {generateButtonText}
+                {resolvedGenerateButton}
               </button>
             </div>
           </div>

--- a/packages/ndpr-toolkit/src/components/consent/ConsentManager.tsx
+++ b/packages/ndpr-toolkit/src/components/consent/ConsentManager.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { ConsentOption, ConsentSettings } from '../../types/consent';
 import { resolveClass } from '../../utils/styling';
+import { useNDPRLocale } from '../NDPRProvider';
 
 export interface ConsentManagerClassNames {
   root?: string;
@@ -123,10 +124,11 @@ export const ConsentManager: React.FC<ConsentManagerProps> = ({
   options,
   settings,
   onSave,
-  title = "Manage Your Privacy Settings",
-  description = "Update your consent preferences at any time. Required cookies cannot be disabled as they are necessary for the website to function. Consent management is provided in accordance with NDPA Sections 25-26.",
-  saveButtonText = "Save Preferences",
-  resetButtonText = "Reset to Defaults",
+  // i18n: explicit prop > provider locale > English default.
+  title,
+  description,
+  saveButtonText,
+  resetButtonText,
   version = "1.0",
   className = "",
   buttonClassName = "",
@@ -138,6 +140,13 @@ export const ConsentManager: React.FC<ConsentManagerProps> = ({
   successMessage = "Your preferences have been saved.",
   successMessageDuration = 3000
 }) => {
+  const locale = useNDPRLocale();
+  const resolvedTitle = title ?? locale.consent.managerTitle ?? 'Manage Your Privacy Settings';
+  const resolvedDescription =
+    description ?? locale.consent.managerDescription ??
+    'Update your consent preferences at any time. Required cookies cannot be disabled as they are necessary for the website to function. Consent management is provided in accordance with NDPA Sections 25-26.';
+  const resolvedSave = saveButtonText ?? locale.consent.savePreferences ?? 'Save Preferences';
+  const resolvedReset = resetButtonText ?? locale.consent.resetToDefaults ?? 'Reset to Defaults';
   const [consents, setConsents] = useState<Record<string, boolean>>({});
   const [showSuccess, setShowSuccess] = useState<boolean>(false);
   const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -234,8 +243,8 @@ export const ConsentManager: React.FC<ConsentManagerProps> = ({
       data-ndpr-component="consent-manager"
       className={resolveClass(rootClass, classNames?.root, unstyled)}
     >
-      <h2 className={resolveClass('ndpr-consent-manager__title', classNames?.title, unstyled)}>{title}</h2>
-      <p className={resolveClass('ndpr-consent-manager__description', classNames?.description, unstyled)}>{description}</p>
+      <h2 className={resolveClass('ndpr-consent-manager__title', classNames?.title, unstyled)}>{resolvedTitle}</h2>
+      <p className={resolveClass('ndpr-consent-manager__description', classNames?.description, unstyled)}>{resolvedDescription}</p>
 
       <div className={resolveClass('ndpr-consent-manager__options-list', classNames?.optionsList, unstyled)}>
         {options.map(option => {
@@ -284,13 +293,13 @@ export const ConsentManager: React.FC<ConsentManagerProps> = ({
           onClick={handleSave}
           className={resolveClass(resolvedSaveButton, classNames?.saveButton, unstyled)}
         >
-          {saveButtonText}
+          {resolvedSave}
         </button>
         <button
           onClick={handleReset}
           className={resolveClass(resolvedResetButton, classNames?.resetButton, unstyled)}
         >
-          {resetButtonText}
+          {resolvedReset}
         </button>
       </div>
 

--- a/packages/ndpr-toolkit/src/components/cross-border/CrossBorderTransferManager.tsx
+++ b/packages/ndpr-toolkit/src/components/cross-border/CrossBorderTransferManager.tsx
@@ -13,6 +13,7 @@ import {
   TransferValidationResult,
 } from '../../utils/cross-border';
 import { resolveClass } from '../../utils/styling';
+import { useNDPRLocale } from '../NDPRProvider';
 
 export interface CrossBorderTransferManagerClassNames {
   root?: string;
@@ -227,8 +228,9 @@ export const CrossBorderTransferManager: React.FC<CrossBorderTransferManagerProp
   onUpdateTransfer,
   onRemoveTransfer,
   summary,
-  title = 'Cross-Border Data Transfer Manager',
-  description = 'Manage and document cross-border personal data transfers in compliance with NDPA 2023 Part VIII (Sections 41-43).',
+  // i18n: explicit prop > provider locale > English default.
+  title,
+  description,
   className = '',
   buttonClassName = '',
   showSummary = true,
@@ -236,6 +238,11 @@ export const CrossBorderTransferManager: React.FC<CrossBorderTransferManagerProp
   classNames,
   unstyled,
 }) => {
+  const locale = useNDPRLocale();
+  const resolvedTitle = title ?? locale.crossBorder.title ?? 'Cross-Border Data Transfer Manager';
+  const resolvedDescription =
+    description ?? locale.crossBorder.description ??
+    'Manage and document cross-border personal data transfers in compliance with NDPA 2023 Part VIII (Sections 41-43).';
   const [selectedTransferId, setSelectedTransferId] = useState<string | null>(null);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editingTransferId, setEditingTransferId] = useState<string | null>(null);
@@ -1232,8 +1239,8 @@ export const CrossBorderTransferManager: React.FC<CrossBorderTransferManagerProp
 
   return (
     <div className={resolveClass(`bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md ${className}`, classNames?.root, unstyled)}>
-      <h2 className={resolveClass('ndpr-section-heading', classNames?.title, unstyled)}>{title}</h2>
-      <p className='ndpr-card__subtitle'>{description}</p>
+      <h2 className={resolveClass('ndpr-section-heading', classNames?.title, unstyled)}>{resolvedTitle}</h2>
+      <p className='ndpr-card__subtitle'>{resolvedDescription}</p>
 
       {/* Compliance Summary */}
       {showSummary && renderSummary()}

--- a/packages/ndpr-toolkit/src/components/cross-border/CrossBorderTransferManagerLite.tsx
+++ b/packages/ndpr-toolkit/src/components/cross-border/CrossBorderTransferManagerLite.tsx
@@ -5,6 +5,7 @@ import {
   AdequacyStatus,
 } from '../../types/cross-border';
 import { resolveClass } from '../../utils/styling';
+import { useNDPRLocale } from '../NDPRProvider';
 
 export interface CrossBorderTransferManagerLiteClassNames {
   root?: string;
@@ -84,8 +85,9 @@ const NDPC_APPROVAL_MECHANISMS: ReadonlySet<TransferMechanism> = new Set<Transfe
  */
 export const CrossBorderTransferManagerLite: React.FC<CrossBorderTransferManagerLiteProps> = ({
   transfers,
-  title = 'Cross-Border Data Transfer Manager',
-  description = 'Manage and document cross-border personal data transfers in compliance with NDPA 2023 Part VIII (Sections 41-43).',
+  // i18n: explicit prop > provider locale > English default.
+  title,
+  description,
   className = '',
   classNames,
   unstyled,
@@ -93,6 +95,11 @@ export const CrossBorderTransferManagerLite: React.FC<CrossBorderTransferManager
   showRiskAlerts = true,
   onTransferClick,
 }) => {
+  const locale = useNDPRLocale();
+  const resolvedTitle = title ?? locale.crossBorder.title ?? 'Cross-Border Data Transfer Manager';
+  const resolvedDescription =
+    description ?? locale.crossBorder.description ??
+    'Manage and document cross-border personal data transfers in compliance with NDPA 2023 Part VIII (Sections 41-43).';
   const sortedTransfers = useMemo(
     () => [...transfers].sort((a, b) => b.updatedAt - a.updatedAt),
     [transfers],
@@ -123,8 +130,8 @@ export const CrossBorderTransferManagerLite: React.FC<CrossBorderTransferManager
       className={resolveClass(`bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md ${className}`, classNames?.root, unstyled)}
     >
       <div className={resolveClass('', classNames?.header, unstyled)}>
-        <h2 className={resolveClass('ndpr-section-heading', classNames?.title, unstyled)}>{title}</h2>
-        <p className="ndpr-card__subtitle">{description}</p>
+        <h2 className={resolveClass('ndpr-section-heading', classNames?.title, unstyled)}>{resolvedTitle}</h2>
+        <p className="ndpr-card__subtitle">{resolvedDescription}</p>
       </div>
 
       {showSummary && (

--- a/packages/ndpr-toolkit/src/components/dpia/DPIAQuestionnaire.tsx
+++ b/packages/ndpr-toolkit/src/components/dpia/DPIAQuestionnaire.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { DPIASection, DPIAQuestion } from '../../types/dpia';
 import { resolveClass } from '../../utils/styling';
+import { useNDPRLocale } from '../NDPRProvider';
 
 export interface DPIAQuestionnaireClassNames {
   /** Outermost wrapper */
@@ -148,14 +149,19 @@ export const DPIAQuestionnaire: React.FC<DPIAQuestionnaireProps> = ({
   readOnly = false,
   className = "",
   buttonClassName = "",
-  nextButtonText = "Next",
-  prevButtonText = "Previous",
-  submitButtonText = "Submit",
+  // i18n: explicit prop > provider locale > English default.
+  nextButtonText,
+  prevButtonText,
+  submitButtonText,
   showProgress = true,
   progress,
   classNames = {},
   unstyled = false,
 }) => {
+  const locale = useNDPRLocale();
+  const resolvedNext = nextButtonText ?? locale.dpia.next ?? 'Next';
+  const resolvedPrev = prevButtonText ?? locale.dpia.previous ?? 'Previous';
+  const resolvedSubmit = submitButtonText ?? locale.dpia.submit ?? 'Submit';
   const currentSection = sections[currentSectionIndex];
   const isLastSection = currentSectionIndex === sections.length - 1;
 
@@ -421,7 +427,7 @@ export const DPIAQuestionnaire: React.FC<DPIAQuestionnaireProps> = ({
           disabled={currentSectionIndex === 0 || readOnly}
           className={`${cx('ndpr-button ndpr-button--secondary', 'prevButton')} ${buttonClassName}`}
         >
-          {prevButtonText}
+          {resolvedPrev}
         </button>
 
         <button
@@ -430,7 +436,7 @@ export const DPIAQuestionnaire: React.FC<DPIAQuestionnaireProps> = ({
           disabled={readOnly}
           className={`${cx('ndpr-button ndpr-button--primary', 'nextButton')} ${buttonClassName}`}
         >
-          {isLastSection ? submitButtonText : nextButtonText}
+          {isLastSection ? resolvedSubmit : resolvedNext}
         </button>
       </div>
     </div>

--- a/packages/ndpr-toolkit/src/components/dpia/DPIAReport.tsx
+++ b/packages/ndpr-toolkit/src/components/dpia/DPIAReport.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { DPIAResult, DPIASection, DPIARisk } from '../../types/dpia';
 import { resolveClass } from '../../utils/styling';
 import { LEGAL_DISCLAIMER_SHORT } from '../../utils/legal-notice';
+import { useNDPRLocale } from '../NDPRProvider';
 
 export interface DPIAReportClassNames {
   /** Outermost wrapper */
@@ -101,6 +102,8 @@ export const DPIAReport: React.FC<DPIAReportProps> = ({
   classNames = {},
   unstyled = false,
 }) => {
+  const locale = useNDPRLocale();
+  const resolvedReportTitle = locale.dpia.reportTitle ?? 'Data Protection Impact Assessment Report';
   const generatedDate = useMemo(() => new Date().toLocaleDateString(), []);
 
   const cx = (defaultClass: string, key?: keyof DPIAReportClassNames) => {
@@ -192,7 +195,7 @@ export const DPIAReport: React.FC<DPIAReportProps> = ({
         <div className="flex justify-between items-start">
           <div>
             <h1 className={cx('ndpr-card__title', 'title')}>
-              Data Protection Impact Assessment Report
+              {resolvedReportTitle}
             </h1>
             <h2 className="text-xl ndpr-text-muted mb-4">
               {result.title}

--- a/packages/ndpr-toolkit/src/components/dsr/DSRDashboard.tsx
+++ b/packages/ndpr-toolkit/src/components/dsr/DSRDashboard.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { DSRRequest, DSRStatus, DSRType } from '../../types/dsr';
 import { formatDSRRequest } from '../../utils/dsr';
 import { resolveClass } from '../../utils/styling';
+import { useNDPRLocale } from '../NDPRProvider';
 
 export interface DSRDashboardClassNames {
   root?: string;
@@ -101,8 +102,9 @@ export const DSRDashboard: React.FC<DSRDashboardProps> = ({
   onSelectRequest,
   onUpdateStatus,
   onAssignRequest,
-  title = "Data Subject Request Dashboard",
-  description = "Track and manage data subject requests in compliance with NDPA Part IV requirements.",
+  // i18n: explicit prop > provider locale > English default.
+  title,
+  description,
   className = "",
   buttonClassName = "",
   showRequestDetails = true,
@@ -112,6 +114,11 @@ export const DSRDashboard: React.FC<DSRDashboardProps> = ({
   classNames,
   unstyled = false
 }) => {
+  const locale = useNDPRLocale();
+  const resolvedTitle = title ?? locale.dsr.dashboardTitle ?? 'Data Subject Request Dashboard';
+  const resolvedDescription =
+    description ?? locale.dsr.dashboardDescription ??
+    'Track and manage data subject requests in compliance with NDPA Part IV requirements.';
   const [selectedRequestId, setSelectedRequestId] = useState<string | null>(null);
   const [filteredRequests, setFilteredRequests] = useState<DSRRequest[]>(requests);
   const [statusFilter, setStatusFilter] = useState<string>('all');
@@ -479,8 +486,8 @@ export const DSRDashboard: React.FC<DSRDashboardProps> = ({
   return (
     <div className={resolveClass(`bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md ${className}`, classNames?.root, unstyled)}>
       <div className={resolveClass("", classNames?.header, unstyled)}>
-        <h2 className={resolveClass("text-xl font-bold mb-2", classNames?.title, unstyled)}>{title}</h2>
-        <p className="mb-6 text-gray-600 dark:text-gray-300">{description}</p>
+        <h2 className={resolveClass("text-xl font-bold mb-2", classNames?.title, unstyled)}>{resolvedTitle}</h2>
+        <p className="mb-6 text-gray-600 dark:text-gray-300">{resolvedDescription}</p>
       </div>
 
       {/* Filters and Search */}

--- a/packages/ndpr-toolkit/src/components/dsr/DSRTracker.tsx
+++ b/packages/ndpr-toolkit/src/components/dsr/DSRTracker.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { DSRRequest, DSRStatus, DSRType } from '../../types/dsr';
 import { resolveClass } from '../../utils/styling';
+import { useNDPRLocale } from '../NDPRProvider';
 
 export interface DSRTrackerClassNames {
   root?: string;
@@ -96,8 +97,9 @@ export interface DSRTrackerProps {
 export const DSRTracker: React.FC<DSRTrackerProps> = ({
   requests,
   onSelectRequest,
-  title = "DSR Request Tracker",
-  description = "Track the status and progress of data subject requests as required by NDPA Part IV.",
+  // i18n: explicit prop > provider locale > English default.
+  title,
+  description,
   className = "",
   buttonClassName = "",
   showSummaryStats = true,
@@ -108,6 +110,11 @@ export const DSRTracker: React.FC<DSRTrackerProps> = ({
   classNames,
   unstyled = false
 }) => {
+  const locale = useNDPRLocale();
+  const resolvedTitle = title ?? locale.dsr.trackerTitle ?? 'DSR Request Tracker';
+  const resolvedDescription =
+    description ?? locale.dsr.trackerDescription ??
+    'Track the status and progress of data subject requests as required by NDPA Part IV.';
   const [selectedTimeframe, setSelectedTimeframe] = useState<'7days' | '30days' | '90days' | 'all'>('30days');
   const [filteredRequests, setFilteredRequests] = useState<DSRRequest[]>(requests);
   const [overdueRequests, setOverdueRequests] = useState<DSRRequest[]>([]);
@@ -623,8 +630,8 @@ export const DSRTracker: React.FC<DSRTrackerProps> = ({
     <div className={resolveClass(`bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md ${className}`, classNames?.root, unstyled)}>
       <div className={resolveClass("flex flex-col md:flex-row md:justify-between md:items-center mb-6", classNames?.header, unstyled)}>
         <div>
-          <h2 className={resolveClass("text-xl font-bold mb-2", classNames?.title, unstyled)}>{title}</h2>
-          <p className="text-gray-600 dark:text-gray-300">{description}</p>
+          <h2 className={resolveClass("text-xl font-bold mb-2", classNames?.title, unstyled)}>{resolvedTitle}</h2>
+          <p className="text-gray-600 dark:text-gray-300">{resolvedDescription}</p>
         </div>
         
         <div className="mt-4 md:mt-0">

--- a/packages/ndpr-toolkit/src/components/lawful-basis/LawfulBasisTracker.tsx
+++ b/packages/ndpr-toolkit/src/components/lawful-basis/LawfulBasisTracker.tsx
@@ -13,6 +13,7 @@ import {
   LawfulBasisComplianceGap,
 } from '../../utils/lawful-basis';
 import { resolveClass } from '../../utils/styling';
+import { useNDPRLocale } from '../NDPRProvider';
 
 export interface LawfulBasisTrackerClassNames {
   root?: string;
@@ -215,8 +216,9 @@ export const LawfulBasisTracker: React.FC<LawfulBasisTrackerProps> = ({
   onAddActivity,
   onUpdateActivity,
   onArchiveActivity,
-  title = 'Lawful Basis Tracker',
-  description = 'Document and track the lawful basis for each processing activity as required by NDPA 2023 Section 25.',
+  // i18n: explicit prop > provider locale > English default.
+  title,
+  description,
   className = '',
   buttonClassName = '',
   showSummary = true,
@@ -224,6 +226,11 @@ export const LawfulBasisTracker: React.FC<LawfulBasisTrackerProps> = ({
   classNames,
   unstyled,
 }) => {
+  const locale = useNDPRLocale();
+  const resolvedTitle = title ?? locale.lawfulBasis.title ?? 'Lawful Basis Tracker';
+  const resolvedDescription =
+    description ?? locale.lawfulBasis.description ??
+    'Document and track the lawful basis for each processing activity as required by NDPA 2023 Section 25.';
   const [viewMode, setViewMode] = useState<ViewMode>('list');
   const [formData, setFormData] = useState<FormData>(EMPTY_FORM);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -1285,8 +1292,8 @@ export const LawfulBasisTracker: React.FC<LawfulBasisTrackerProps> = ({
 
   return (
     <div className={resolveClass(`bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md ${className}`, classNames?.root, unstyled)}>
-      <h2 className={resolveClass('ndpr-section-heading', classNames?.title, unstyled)}>{title}</h2>
-      <p className='ndpr-card__subtitle'>{description}</p>
+      <h2 className={resolveClass('ndpr-section-heading', classNames?.title, unstyled)}>{resolvedTitle}</h2>
+      <p className='ndpr-card__subtitle'>{resolvedDescription}</p>
 
       {/* Compliance Summary */}
       {showSummary && viewMode === 'list' && renderSummary()}

--- a/packages/ndpr-toolkit/src/components/lawful-basis/LawfulBasisTrackerLite.tsx
+++ b/packages/ndpr-toolkit/src/components/lawful-basis/LawfulBasisTrackerLite.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { LawfulBasis, ProcessingActivity, LawfulBasisSummary } from '../../types/lawful-basis';
 import { assessComplianceGaps, generateLawfulBasisSummary, LawfulBasisComplianceGap } from '../../utils/lawful-basis';
 import { resolveClass } from '../../utils/styling';
+import { useNDPRLocale } from '../NDPRProvider';
 
 export interface LawfulBasisTrackerLiteClassNames {
   root?: string;
@@ -65,8 +66,9 @@ const formatDate = (timestamp: number): string => new Date(timestamp).toLocaleDa
 
 export const LawfulBasisTrackerLite: React.FC<LawfulBasisTrackerLiteProps> = ({
   activities,
-  title = 'Lawful Basis Tracker',
-  description = 'Document and track the lawful basis for each processing activity as required by NDPA 2023 Section 25.',
+  // i18n: explicit prop > provider locale > English default.
+  title,
+  description,
   className = '',
   classNames,
   unstyled,
@@ -74,6 +76,11 @@ export const LawfulBasisTrackerLite: React.FC<LawfulBasisTrackerLiteProps> = ({
   showComplianceGaps = true,
   onActivityClick,
 }) => {
+  const locale = useNDPRLocale();
+  const resolvedTitle = title ?? locale.lawfulBasis.title ?? 'Lawful Basis Tracker';
+  const resolvedDescription =
+    description ?? locale.lawfulBasis.description ??
+    'Document and track the lawful basis for each processing activity as required by NDPA 2023 Section 25.';
   const sortedActivities = useMemo(() => [...activities].sort((a, b) => b.updatedAt - a.updatedAt), [activities]);
   const summary: LawfulBasisSummary = useMemo(() => generateLawfulBasisSummary(activities), [activities]);
   const complianceGaps: LawfulBasisComplianceGap[] = useMemo(() => assessComplianceGaps(activities), [activities]);
@@ -174,8 +181,8 @@ export const LawfulBasisTrackerLite: React.FC<LawfulBasisTrackerLiteProps> = ({
   return (
     <div className={resolveClass(`bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md ${className}`, classNames?.root, unstyled)}>
       <div className={resolveClass('', classNames?.header, unstyled)}>
-        <h2 className={resolveClass('ndpr-section-heading', classNames?.title, unstyled)}>{title}</h2>
-        <p className="ndpr-card__subtitle">{description}</p>
+        <h2 className={resolveClass('ndpr-section-heading', classNames?.title, unstyled)}>{resolvedTitle}</h2>
+        <p className="ndpr-card__subtitle">{resolvedDescription}</p>
       </div>
 
       {showSummary && renderSummary()}

--- a/packages/ndpr-toolkit/src/components/policy/AdaptivePolicyWizard.tsx
+++ b/packages/ndpr-toolkit/src/components/policy/AdaptivePolicyWizard.tsx
@@ -4,6 +4,7 @@ import type { PolicyDraft, TemplateContext } from '../../types/policy-engine';
 import type { StorageAdapter } from '../../adapters/types';
 import { resolveClass } from '../../utils/styling';
 import { useAdaptivePolicyWizard } from '../../hooks/useAdaptivePolicyWizard';
+import { useNDPRLocale } from '../NDPRProvider';
 import { PolicyStepIndicator } from './PolicyStepIndicator';
 import { PolicyStepAbout } from './PolicyStepAbout';
 import { PolicyStepData } from './PolicyStepData';
@@ -32,6 +33,10 @@ export const AdaptivePolicyWizard: React.FC<AdaptivePolicyWizardProps> = ({
   unstyled,
   initialContext,
 }) => {
+  const locale = useNDPRLocale();
+  const resolvedWizardTitle = locale.policy.wizardTitle ?? 'Privacy Policy Builder';
+  const resolvedBack = locale.common.back ?? 'Back';
+  const resolvedNext = locale.common.next ?? 'Next';
   const {
     currentStep,
     nextStep,
@@ -164,7 +169,7 @@ export const AdaptivePolicyWizard: React.FC<AdaptivePolicyWizardProps> = ({
               unstyled,
             )}
           >
-            Privacy Policy Builder
+            {resolvedWizardTitle}
           </h1>
           <DraftSaveIndicator
             lastSavedAt={lastSavedAt}
@@ -271,7 +276,7 @@ export const AdaptivePolicyWizard: React.FC<AdaptivePolicyWizardProps> = ({
                   unstyled,
                 )}
               >
-                Back
+                {resolvedBack}
               </button>
 
               <div className="flex items-center gap-2">
@@ -297,7 +302,7 @@ export const AdaptivePolicyWizard: React.FC<AdaptivePolicyWizardProps> = ({
                     unstyled,
                   )}
                 >
-                  Next
+                  {resolvedNext}
                 </button>
               ) : (
                 <span />

--- a/packages/ndpr-toolkit/src/components/policy/PolicyExporter.tsx
+++ b/packages/ndpr-toolkit/src/components/policy/PolicyExporter.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useId } from 'react';
 import { resolveClass } from '../../utils/styling';
+import { useNDPRLocale } from '../NDPRProvider';
 
 export interface PolicyExporterClassNames {
   /** Root container */
@@ -122,12 +123,13 @@ interface ExportRecord {
 
 export const PolicyExporter: React.FC<PolicyExporterProps> = ({
   content,
-  title = "Privacy Policy",
+  // i18n: explicit prop > provider locale > English default.
+  title,
   organizationName,
   lastUpdated,
   onExportComplete,
   componentTitle = "Export Privacy Policy",
-  description = "Export your NDPA-compliant privacy policy in various formats.",
+  description,
   className = "",
   buttonClassName = "",
   showExportHistory = true,
@@ -138,6 +140,11 @@ export const PolicyExporter: React.FC<PolicyExporterProps> = ({
   classNames,
   unstyled = false
 }) => {
+  const locale = useNDPRLocale();
+  const resolvedTitle = title ?? locale.policy.exporterTitle ?? 'Privacy Policy';
+  const resolvedDescription =
+    description ?? locale.policy.exporterDescription ??
+    'Export your NDPA-compliant privacy policy in various formats.';
   const instanceId = useId();
   const [exportHistory, setExportHistory] = useState<ExportRecord[]>([]);
   const [selectedFormat, setSelectedFormat] = useState<string>('pdf');
@@ -174,7 +181,7 @@ export const PolicyExporter: React.FC<PolicyExporterProps> = ({
   
   // Generate HTML content for export
   const generateHTMLContent = (): string => {
-    const fullTitle = organizationName ? `${organizationName} ${title}` : title;
+    const fullTitle = organizationName ? `${organizationName} ${resolvedTitle}` : resolvedTitle;
     const dateStr = lastUpdated ? lastUpdated.toLocaleDateString() : 'N/A';
     
     let html = `<!DOCTYPE html>
@@ -554,7 +561,7 @@ export const PolicyExporter: React.FC<PolicyExporterProps> = ({
     <div className={resolveClass(`bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md ${className}`, classNames?.root, unstyled)}>
       <div className={resolveClass('mb-6', classNames?.header, unstyled)}>
         <h2 className={resolveClass('ndpr-section-heading', classNames?.title, unstyled)}>{componentTitle}</h2>
-        <p className={resolveClass('ndpr-card__subtitle', classNames?.description, unstyled)}>{description}</p>
+        <p className={resolveClass('ndpr-card__subtitle', classNames?.description, unstyled)}>{resolvedDescription}</p>
       </div>
       
       {/* Format Selection */}

--- a/packages/ndpr-toolkit/src/components/policy/PolicyGenerator.tsx
+++ b/packages/ndpr-toolkit/src/components/policy/PolicyGenerator.tsx
@@ -3,6 +3,7 @@ import { generatePolicyText } from '../../utils/privacy';
 import { resolveClass } from '../../utils/styling';
 import { PolicySection, PolicyVariable } from '../../types/privacy';
 import { DEFAULT_POLICY_SECTIONS, DEFAULT_POLICY_VARIABLES } from '../../utils/policy-templates';
+import { useNDPRLocale } from '../NDPRProvider';
 
 export interface PolicyGeneratorClassNames {
   /** Root container */
@@ -107,16 +108,23 @@ export const PolicyGenerator: React.FC<PolicyGeneratorProps> = ({
   sections: initialSections = DEFAULT_POLICY_SECTIONS,
   variables: initialVariables = DEFAULT_POLICY_VARIABLES,
   onGenerate,
-  title = "NDPA Privacy Policy Generator",
-  description = "Generate an NDPA-compliant privacy policy for your organization in accordance with NDPA Section 24.",
+  // i18n: explicit prop > provider locale > English default.
+  title,
+  description,
   className = "",
   buttonClassName = "",
-  generateButtonText = "Generate Policy",
+  generateButtonText,
   showPreview = true,
   allowEditing = true,
   classNames,
   unstyled = false
 }) => {
+  const locale = useNDPRLocale();
+  const resolvedTitle = title ?? locale.policy.generatorTitle ?? 'NDPA Privacy Policy Generator';
+  const resolvedDescription =
+    description ?? locale.policy.generatorDescription ??
+    'Generate an NDPA-compliant privacy policy for your organization in accordance with NDPA Section 24.';
+  const resolvedGenerateButton = generateButtonText ?? locale.policy.generate ?? 'Generate Policy';
   const instanceId = useId();
   const [sections, setSections] = useState<PolicySection[]>(initialSections);
   const [variables, setVariables] = useState<PolicyVariable[]>(initialVariables);
@@ -398,7 +406,7 @@ export const PolicyGenerator: React.FC<PolicyGeneratorProps> = ({
             onClick={generatePolicy}
             className={resolveClass(`px-4 py-2 bg-[rgb(var(--ndpr-primary))] text-white rounded hover:bg-[rgb(var(--ndpr-primary-hover))] ${buttonClassName}`, classNames?.primaryButton || classNames?.generateButton, unstyled)}
           >
-            {generateButtonText}
+            {resolvedGenerateButton}
           </button>
         </div>
       </div>
@@ -478,8 +486,8 @@ export const PolicyGenerator: React.FC<PolicyGeneratorProps> = ({
   return (
     <div className={resolveClass(`bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md ${className}`, classNames?.root, unstyled)}>
       <div className={resolveClass('mb-6', classNames?.header, unstyled)}>
-        <h2 className={resolveClass('ndpr-section-heading', classNames?.title, unstyled)}>{title}</h2>
-        <p className={resolveClass('ndpr-card__subtitle', classNames?.description, unstyled)}>{description}</p>
+        <h2 className={resolveClass('ndpr-section-heading', classNames?.title, unstyled)}>{resolvedTitle}</h2>
+        <p className={resolveClass('ndpr-card__subtitle', classNames?.description, unstyled)}>{resolvedDescription}</p>
       </div>
       
       {/* Steps Indicator */}

--- a/packages/ndpr-toolkit/src/components/policy/PolicyPreview.tsx
+++ b/packages/ndpr-toolkit/src/components/policy/PolicyPreview.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useId } from 'react';
 import { resolveClass } from '../../utils/styling';
 import { PolicySection, PolicyVariable } from '../../types/privacy';
+import { useNDPRLocale } from '../NDPRProvider';
 
 export interface PolicyPreviewClassNames {
   /** Root container */
@@ -123,8 +124,9 @@ export const PolicyPreview: React.FC<PolicyPreviewProps> = ({
   variables,
   onExport,
   onEdit,
-  title = "Privacy Policy Preview",
-  description = "Preview your NDPA-compliant privacy policy before exporting.",
+  // i18n: explicit prop > provider locale > English default.
+  title,
+  description,
   className = "",
   buttonClassName = "",
   showExportOptions = true,
@@ -136,6 +138,11 @@ export const PolicyPreview: React.FC<PolicyPreviewProps> = ({
   classNames,
   unstyled = false
 }) => {
+  const locale = useNDPRLocale();
+  const resolvedTitle = title ?? locale.policy.previewTitle ?? 'Privacy Policy Preview';
+  const resolvedDescription =
+    description ?? locale.policy.previewDescription ??
+    'Preview your NDPA-compliant privacy policy before exporting.';
   const instanceId = useId();
   const [activeTab, setActiveTab] = useState<'preview' | 'markdown'>('preview');
   const previewTabId = `${instanceId}-tab-preview`;
@@ -293,8 +300,8 @@ export const PolicyPreview: React.FC<PolicyPreviewProps> = ({
     <div className={resolveClass(`bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md ${className}`, classNames?.root, unstyled)}>
       <div className={resolveClass('flex justify-between items-start mb-6', classNames?.header, unstyled)}>
         <div>
-          <h2 className={resolveClass('ndpr-section-heading', classNames?.title, unstyled)}>{title}</h2>
-          <p className={resolveClass('ndpr-card__subtitle', classNames?.description, unstyled)}>{description}</p>
+          <h2 className={resolveClass('ndpr-section-heading', classNames?.title, unstyled)}>{resolvedTitle}</h2>
+          <p className={resolveClass('ndpr-card__subtitle', classNames?.description, unstyled)}>{resolvedDescription}</p>
         </div>
         
         {showEditButton && onEdit && (

--- a/packages/ndpr-toolkit/src/components/ropa/ROPAManager.tsx
+++ b/packages/ndpr-toolkit/src/components/ropa/ROPAManager.tsx
@@ -13,6 +13,7 @@ import {
   identifyComplianceGaps,
 } from '../../utils/ropa';
 import { resolveClass } from '../../utils/styling';
+import { useNDPRLocale } from '../NDPRProvider';
 
 export interface ROPAManagerClassNames {
   root?: string;
@@ -179,13 +180,19 @@ export const ROPAManager: React.FC<ROPAManagerProps> = ({
   onAddRecord,
   onUpdateRecord,
   onArchiveRecord,
-  title = 'Record of Processing Activities (ROPA)',
-  description = 'Maintain a comprehensive record of all data processing activities as required by the NDPA accountability principle.',
+  // i18n: explicit prop > provider locale > English default.
+  title,
+  description,
   className = '',
   buttonClassName = '',
   classNames,
   unstyled,
 }) => {
+  const locale = useNDPRLocale();
+  const resolvedTitle = title ?? locale.ropa.title ?? 'Record of Processing Activities (ROPA)';
+  const resolvedDescription =
+    description ?? locale.ropa.description ??
+    'Maintain a comprehensive record of all data processing activities as required by the NDPA accountability principle.';
   const [viewMode, setViewMode] = useState<ViewMode>('list');
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('all');
@@ -1252,8 +1259,8 @@ export const ROPAManager: React.FC<ROPAManagerProps> = ({
 
   return (
     <div className={resolveClass(`bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md ${className}`, classNames?.root, unstyled)}>
-      <h2 className={resolveClass('ndpr-section-heading', classNames?.title, unstyled)}>{title}</h2>
-      <p className='ndpr-card__subtitle'>{description}</p>
+      <h2 className={resolveClass('ndpr-section-heading', classNames?.title, unstyled)}>{resolvedTitle}</h2>
+      <p className='ndpr-card__subtitle'>{resolvedDescription}</p>
 
       {renderOrganizationHeader()}
 

--- a/packages/ndpr-toolkit/src/components/ropa/ROPAManagerLite.tsx
+++ b/packages/ndpr-toolkit/src/components/ropa/ROPAManagerLite.tsx
@@ -4,6 +4,7 @@ import type { ProcessingRecord, RecordOfProcessingActivities } from '../../types
 import type { ROPAComplianceGap } from '../../utils/ropa';
 import { generateROPASummary, identifyComplianceGaps } from '../../utils/ropa';
 import { resolveClass } from '../../utils/styling';
+import { useNDPRLocale } from '../NDPRProvider';
 
 export interface ROPAManagerLiteClassNames {
   root?: string;
@@ -59,8 +60,9 @@ function isReviewOverdue(record: ProcessingRecord): boolean {
 
 export const ROPAManagerLite: React.FC<ROPAManagerLiteProps> = ({
   records,
-  title = 'Record of Processing Activities (ROPA)',
-  description = 'Maintain a comprehensive record of all data processing activities as required by the NDPA accountability principle.',
+  // i18n: explicit prop > provider locale > English default.
+  title,
+  description,
   className = '',
   classNames,
   unstyled,
@@ -68,6 +70,11 @@ export const ROPAManagerLite: React.FC<ROPAManagerLiteProps> = ({
   showComplianceGaps = true,
   onRecordClick,
 }) => {
+  const locale = useNDPRLocale();
+  const resolvedTitle = title ?? locale.ropa.title ?? 'Record of Processing Activities (ROPA)';
+  const resolvedDescription =
+    description ?? locale.ropa.description ??
+    'Maintain a comprehensive record of all data processing activities as required by the NDPA accountability principle.';
   const ropaStub = useMemo<RecordOfProcessingActivities>(
     () => ({
       id: 'lite',
@@ -89,8 +96,8 @@ export const ROPAManagerLite: React.FC<ROPAManagerLiteProps> = ({
   return (
     <div className={resolveClass(`bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md ${className}`, classNames?.root, unstyled)}>
       <div className={resolveClass('', classNames?.header, unstyled)}>
-        <h2 className={resolveClass('ndpr-section-heading', classNames?.title, unstyled)}>{title}</h2>
-        <p className='ndpr-card__subtitle'>{description}</p>
+        <h2 className={resolveClass('ndpr-section-heading', classNames?.title, unstyled)}>{resolvedTitle}</h2>
+        <p className='ndpr-card__subtitle'>{resolvedDescription}</p>
       </div>
 
       {showSummary && (

--- a/packages/ndpr-toolkit/src/hooks/useDSR.ts
+++ b/packages/ndpr-toolkit/src/hooks/useDSR.ts
@@ -142,6 +142,34 @@ export function useDSR({
   onSubmit,
   onUpdate,
 }: UseDSROptions): UseDSRReturn {
+  // Privacy guard (since 3.13.0): warn (dev-only, fire-once) when no
+  // explicit adapter is configured AND the default localStorage path is
+  // active. `useDSR` is the admin-tracker hook — its state contains
+  // OTHER PEOPLE'S PII (DSR requests submitted by data subjects), and
+  // localStorage on the admin's browser is rarely the right place to
+  // hold it. Slated for behavior change in 4.0: default will switch to
+  // an in-memory adapter; localStorage will require explicit opt-in.
+  const warnedRef = useRef(false);
+  if (
+    !warnedRef.current &&
+    !adapter &&
+    useLocalStorage &&
+    typeof process !== 'undefined' &&
+    process.env?.NODE_ENV !== 'production'
+  ) {
+    warnedRef.current = true;
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[ndpr-toolkit/dsr] useDSR() is using the default localStorageAdapter, ' +
+        "which stores DSR requests (including data subjects' PII) in the admin's " +
+        'browser. For production deployments, pass an explicit adapter ' +
+        '(apiAdapter for server-side persistence, memoryAdapter for in-process, ' +
+        "or set useLocalStorage: false to disable). In 4.0, the default will " +
+        'switch to in-memory; localStorage will require explicit opt-in. See ' +
+        'https://ndprtoolkit.com.ng/docs/guides/upgrading-3-7-to-3-10#dsr-storage',
+    );
+  }
+
   const resolvedAdapter = adapter ?? resolveAdapter(storageKey, useLocalStorage);
   const adapterRef = useRef(resolvedAdapter);
   adapterRef.current = resolvedAdapter;

--- a/packages/ndpr-toolkit/src/locales/en.ts
+++ b/packages/ndpr-toolkit/src/locales/en.ts
@@ -14,6 +14,9 @@ export const defaultLocale: Required<{
     deselectAll: 'Deselect All',
     required: 'Required',
     cookieNotice: 'By clicking "Accept All", you agree to the use of ALL cookies. Visit our Cookie Policy to learn more.',
+    managerTitle: 'Manage Your Privacy Settings',
+    managerDescription: 'Update your consent preferences at any time. Required cookies cannot be disabled as they are necessary for the website to function. Consent management is provided in accordance with NDPA Sections 25-26.',
+    resetToDefaults: 'Reset to Defaults',
   },
   dsr: {
     title: 'Submit a Data Subject Request',
@@ -30,6 +33,10 @@ export const defaultLocale: Required<{
     identifierValue: 'Identifier Value',
     privacyNotice: 'The information you provide in this form will be used solely for the purpose of processing your data subject request.',
     successMessage: 'Your request has been submitted successfully.',
+    dashboardTitle: 'Data Subject Request Dashboard',
+    dashboardDescription: 'Track and manage data subject requests in compliance with NDPA Part IV requirements.',
+    trackerTitle: 'DSR Request Tracker',
+    trackerDescription: 'Track the status and progress of data subject requests as required by NDPA Part IV.',
   },
   breach: {
     title: 'Report a Data Breach',
@@ -39,6 +46,12 @@ export const defaultLocale: Required<{
     category: 'Category',
     discoveredAt: 'Date Discovered',
     detailedDescription: 'Detailed Description',
+    riskAssessmentTitle: 'Breach Risk Assessment',
+    riskAssessmentDescription: 'Assess the risk level of this data breach to determine notification requirements under NDPA Section 40.',
+    notificationManagerTitle: 'Breach Notification Manager',
+    notificationManagerDescription: 'Manage data breach notifications and track compliance with NDPA Section 40 requirements.',
+    regulatoryReportTitle: 'Generate NDPC Notification Report',
+    regulatoryReportDescription: 'Generate a report for submission to the NDPC in compliance with NDPA Section 40 breach notification requirements.',
   },
   dpia: {
     title: 'Data Protection Impact Assessment',
@@ -46,6 +59,8 @@ export const defaultLocale: Required<{
     previous: 'Previous',
     complete: 'Complete Assessment',
     progress: 'Progress',
+    submit: 'Submit',
+    reportTitle: 'Data Protection Impact Assessment Report',
   },
   policy: {
     title: 'Privacy Policy Generator',
@@ -54,6 +69,25 @@ export const defaultLocale: Required<{
     export: 'Export',
     sections: 'Sections',
     variables: 'Variables',
+    generatorTitle: 'NDPA Privacy Policy Generator',
+    generatorDescription: 'Generate an NDPA-compliant privacy policy for your organization in accordance with NDPA Section 24.',
+    previewTitle: 'Privacy Policy Preview',
+    previewDescription: 'Preview your NDPA-compliant privacy policy before exporting.',
+    exporterTitle: 'Privacy Policy',
+    exporterDescription: 'Export your NDPA-compliant privacy policy in various formats.',
+    wizardTitle: 'Privacy Policy Builder',
+  },
+  lawfulBasis: {
+    title: 'Lawful Basis Tracker',
+    description: 'Document and track the lawful basis for each processing activity as required by NDPA 2023 Section 25.',
+  },
+  crossBorder: {
+    title: 'Cross-Border Data Transfer Manager',
+    description: 'Manage and document cross-border personal data transfers in compliance with NDPA 2023 Part VIII (Sections 41-43).',
+  },
+  ropa: {
+    title: 'Record of Processing Activities (ROPA)',
+    description: 'Maintain a comprehensive record of all data processing activities as required by the NDPA accountability principle.',
   },
   compliance: {
     score: 'Compliance Score',

--- a/packages/ndpr-toolkit/src/locales/ha.ts
+++ b/packages/ndpr-toolkit/src/locales/ha.ts
@@ -14,6 +14,9 @@ export const hausaLocale: Required<{
     deselectAll: 'Cire Duka',
     required: 'Wajibi Ne',
     cookieNotice: 'Ta hanyar danna "Karɓi Duka", ka yarda da amfani da dukkan kukis. Ziyarci Manufar Kukis don ƙarin bayani.',
+    managerTitle: 'Sarrafa Saitunan Sirrinka',
+    managerDescription: 'Sabunta zaɓuɓɓukan yardar ka a kowane lokaci. Ba za a iya kashe kukis na wajibi ba domin suna da muhimmanci ga yadda gidan yanar gizo ke aiki. Ana samar da sarrafa yarda bisa ga Sashe na 25-26 na NDPA.',
+    resetToDefaults: 'Sake Saiti zuwa Tsoffi',
   },
   dsr: {
     title: 'Ƙaddamar da Buƙatar Mai Bayanan',
@@ -30,6 +33,10 @@ export const hausaLocale: Required<{
     identifierValue: 'Darajar Ganewa',
     privacyNotice: 'Za a yi amfani da bayanan da ka bayar a cikin wannan fom ne kawai don sarrafa buƙatar mai bayanan ka.',
     successMessage: 'An ƙaddamar da buƙatar ka cikin nasara.',
+    dashboardTitle: 'Dandalin Buƙatun Masu Bayanan',
+    dashboardDescription: 'Bibiyar da sarrafa buƙatun masu bayanan bisa ga buƙatun Bangare na IV na NDPA.',
+    trackerTitle: 'Mai Bin Diddigin Buƙatun DSR',
+    trackerDescription: 'Bin diddigin matsayi da ci gaban buƙatun masu bayanan kamar yadda Bangare na IV na NDPA ya buƙata.',
   },
   breach: {
     title: 'Bayar da Rahoton Karya Bayanan',
@@ -39,6 +46,12 @@ export const hausaLocale: Required<{
     category: 'Rukunin',
     discoveredAt: 'Ranar da Aka Gano',
     detailedDescription: 'Cikakken Bayani',
+    riskAssessmentTitle: 'Tantance Haɗarin Karya Bayanan',
+    riskAssessmentDescription: 'Tantance matakin haɗarin karya bayanan don tantance buƙatun sanarwa a ƙarƙashin Sashe na 40 na NDPA.',
+    notificationManagerTitle: 'Mai Sarrafa Sanarwar Karya Bayanan',
+    notificationManagerDescription: 'Sarrafa sanarwar karya bayanan da bin diddigin bin doka tare da buƙatun Sashe na 40 na NDPA.',
+    regulatoryReportTitle: 'Ƙirƙiri Rahoton Sanarwa na NDPC',
+    regulatoryReportDescription: 'Ƙirƙiri rahoto don ƙaddamarwa ga NDPC bisa ga buƙatun sanarwar karya bayanan na Sashe na 40 na NDPA.',
   },
   dpia: {
     title: 'Tantance Tasirin Kare Bayanan',
@@ -46,6 +59,8 @@ export const hausaLocale: Required<{
     previous: 'Na Baya',
     complete: 'Kammala Tantancewa',
     progress: 'Ci Gaba',
+    submit: 'Ƙaddamar',
+    reportTitle: 'Rahoton Tantance Tasirin Kare Bayanan',
   },
   policy: {
     title: 'Mai Ƙirƙirar Manufar Sirri',
@@ -54,6 +69,25 @@ export const hausaLocale: Required<{
     export: 'Fitar',
     sections: 'Sassa',
     variables: 'Masu Canjin',
+    generatorTitle: 'Mai Ƙirƙirar Manufar Sirri ta NDPA',
+    generatorDescription: 'Ƙirƙiri manufar sirri da ke bin NDPA don kungiyar ka bisa ga Sashe na 24 na NDPA.',
+    previewTitle: 'Dubawar Manufar Sirri',
+    previewDescription: 'Duba manufar sirrin ka da ke bin NDPA kafin fitarwa.',
+    exporterTitle: 'Manufar Sirri',
+    exporterDescription: 'Fitar da manufar sirrin ka da ke bin NDPA a tsare-tsare daban-daban.',
+    wizardTitle: 'Mai Gina Manufar Sirri',
+  },
+  lawfulBasis: {
+    title: 'Mai Bin Diddigin Tushen Doka',
+    description: 'Rubuta da bin diddigin tushen doka don kowane aikin sarrafa bisa ga Sashe na 25 na NDPA 2023.',
+  },
+  crossBorder: {
+    title: 'Mai Sarrafa Canja Wurin Bayanan Ƙetare',
+    description: 'Sarrafa da rubuta canja wurin bayanan na sirri ƙetare bisa ga NDPA 2023 Bangare na VIII (Sashe 41-43).',
+  },
+  ropa: {
+    title: 'Bayanin Ayyukan Sarrafa (ROPA)',
+    description: 'Kiyaye cikakken bayanai na duk ayyukan sarrafa bayanan kamar yadda ka\'idar ɗaukar nauyi ta NDPA ta buƙata.',
   },
   compliance: {
     score: 'Makin Bin Doka',

--- a/packages/ndpr-toolkit/src/locales/ig.ts
+++ b/packages/ndpr-toolkit/src/locales/ig.ts
@@ -14,6 +14,9 @@ export const igboLocale: Required<{
     deselectAll: 'Wepụ Niile',
     required: 'Achọrọ',
     cookieNotice: 'Site na ịpị "Nabata Niile", ị kwenyere na iji kuki niile. Gaa na Amụma Kuki anyị ịmụtakwu.',
+    managerTitle: 'Jikwaa Ntọala Nzuzo Gị',
+    managerDescription: 'Melite mmasị nkwenye gị mgbe ọ bụla. Enweghị ike ịgbanyụ kuki ndị achọrọ ebe ọ bụ na ha dị mkpa maka ka weebụsaịtị rụọ ọrụ. A na-enye njikwa nkwenye dịka NDPA Ngalaba 25-26 si kwuo.',
+    resetToDefaults: 'Tọgharịa na Ndabara',
   },
   dsr: {
     title: 'Tinye Arịrịọ Onye Nwe Data',
@@ -30,6 +33,10 @@ export const igboLocale: Required<{
     identifierValue: 'Uru Njirimara',
     privacyNotice: 'A ga-eji ozi ị nyere na fọọmụ a naanị maka ebumnuche nke ilekọta arịrịọ onye nwe data gị.',
     successMessage: 'Etinyela arịrịọ gị nke ọma.',
+    dashboardTitle: 'Dashboard Arịrịọ Onye Nwe Data',
+    dashboardDescription: 'Soro ma jikwaa arịrịọ ndị nwe data dịka NDPA Nkebi IV si chọọ.',
+    trackerTitle: 'Onye Na-eso Arịrịọ DSR',
+    trackerDescription: 'Soro ọkwa na ọganihu arịrịọ ndị nwe data dịka NDPA Nkebi IV si chọọ.',
   },
   breach: {
     title: 'Kọọ Mwapụ Data',
@@ -39,6 +46,12 @@ export const igboLocale: Required<{
     category: 'Udi',
     discoveredAt: 'Ụbọchị A Chọpụtara',
     detailedDescription: 'Nkọwa Zuru Oke',
+    riskAssessmentTitle: 'Nyocha Ihe Egwu Mwapụ',
+    riskAssessmentDescription: 'Nyochaa ọkwa ihe egwu nke mwapụ data a iji kpebie ihe achọrọ ọkwa n\'okpuru NDPA Ngalaba 40.',
+    notificationManagerTitle: 'Onye Njikwa Ọkwa Mwapụ',
+    notificationManagerDescription: 'Jikwaa ọkwa mwapụ data ma soro nrubeisi na NDPA Ngalaba 40.',
+    regulatoryReportTitle: 'Mepụta Akụkọ Ọkwa NDPC',
+    regulatoryReportDescription: 'Mepụta akụkọ maka ntinye nye NDPC na nrubeisi na NDPA Ngalaba 40.',
   },
   dpia: {
     title: 'Nyocha Mmetụta Nchedo Data',
@@ -46,6 +59,8 @@ export const igboLocale: Required<{
     previous: 'Azụ',
     complete: 'Mechaa Nyocha',
     progress: 'Ọganihu',
+    submit: 'Tinye',
+    reportTitle: 'Akụkọ Nyocha Mmetụta Nchedo Data',
   },
   policy: {
     title: 'Ngwa Mmepụta Amụma Nzuzo',
@@ -54,6 +69,25 @@ export const igboLocale: Required<{
     export: 'Bupụta',
     sections: 'Ngalaba',
     variables: 'Mgbanwe',
+    generatorTitle: 'Ngwa Mmepụta Amụma Nzuzo NDPA',
+    generatorDescription: 'Mepụta amụma nzuzo dakọtara na NDPA maka nzukọ gị dịka NDPA Ngalaba 24 si kwuo.',
+    previewTitle: 'Nlele Amụma Nzuzo',
+    previewDescription: 'Lelee amụma nzuzo gị dakọtara na NDPA tupu ibupụ ya.',
+    exporterTitle: 'Amụma Nzuzo',
+    exporterDescription: 'Bupụta amụma nzuzo gị dakọtara na NDPA n\'ụdị dị iche iche.',
+    wizardTitle: 'Onye Wuli Amụma Nzuzo',
+  },
+  lawfulBasis: {
+    title: 'Onye Na-eso Ihe Ndabere Iwu',
+    description: 'Dee ma soro ihe ndabere iwu maka ọrụ nhazi ọ bụla dịka NDPA 2023 Ngalaba 25 si chọọ.',
+  },
+  crossBorder: {
+    title: 'Onye Njikwa Mbufe Data Gafee Oke',
+    description: 'Jikwaa ma dee mbufe data nke onwe gafee oke na nrubeisi na NDPA 2023 Akụkụ VIII (Ngalaba 41-43).',
+  },
+  ropa: {
+    title: 'Ndekọ Ọrụ Nhazi (ROPA)',
+    description: 'Debe ndekọ zuru oke nke ọrụ nhazi data niile dịka ụkpụrụ ịza ajụjụ NDPA si chọọ.',
   },
   compliance: {
     score: 'Akara Ndabere',

--- a/packages/ndpr-toolkit/src/locales/pcm.ts
+++ b/packages/ndpr-toolkit/src/locales/pcm.ts
@@ -14,6 +14,9 @@ export const pidginLocale: Required<{
     deselectAll: 'Remove Everything',
     required: 'E Dey Required',
     cookieNotice: 'If you click "Accept Everything", you don agree say we fit use all the cookies. Check our Cookie Policy to sabi more.',
+    managerTitle: 'Manage Your Privacy Settings',
+    managerDescription: 'You fit update your consent preferences any time. We no fit disable required cookies because dem dey necessary to make the website work. We dey provide consent management as NDPA Sections 25-26 talk am.',
+    resetToDefaults: 'Reset to Default',
   },
   dsr: {
     title: 'Send Data Subject Request',
@@ -30,6 +33,10 @@ export const pidginLocale: Required<{
     identifierValue: 'ID Value',
     privacyNotice: 'The information wey you give for this form, na only for processing your data subject request we go use am.',
     successMessage: 'We don receive your request successfully.',
+    dashboardTitle: 'Data Subject Request Dashboard',
+    dashboardDescription: 'Track and manage data subject requests as NDPA Part IV talk am.',
+    trackerTitle: 'DSR Request Tracker',
+    trackerDescription: 'Track the status and progress of data subject requests as NDPA Part IV talk am.',
   },
   breach: {
     title: 'Report Data Breach',
@@ -39,6 +46,12 @@ export const pidginLocale: Required<{
     category: 'Category',
     discoveredAt: 'Date Wey You Discover Am',
     detailedDescription: 'Full Gist About Wetin Happen',
+    riskAssessmentTitle: 'Breach Risk Assessment',
+    riskAssessmentDescription: 'Assess the risk level of this data breach to determine wetin you need to notify under NDPA Section 40.',
+    notificationManagerTitle: 'Breach Notification Manager',
+    notificationManagerDescription: 'Manage data breach notifications and track compliance with NDPA Section 40 requirements.',
+    regulatoryReportTitle: 'Generate NDPC Notification Report',
+    regulatoryReportDescription: 'Generate report for submission to NDPC as NDPA Section 40 breach notification requirements talk am.',
   },
   dpia: {
     title: 'Data Protection Impact Assessment',
@@ -46,6 +59,8 @@ export const pidginLocale: Required<{
     previous: 'Go Back',
     complete: 'Finish Assessment',
     progress: 'Progress',
+    submit: 'Submit',
+    reportTitle: 'Data Protection Impact Assessment Report',
   },
   policy: {
     title: 'Privacy Policy Generator',
@@ -54,6 +69,25 @@ export const pidginLocale: Required<{
     export: 'Export',
     sections: 'Sections',
     variables: 'Variables',
+    generatorTitle: 'NDPA Privacy Policy Generator',
+    generatorDescription: 'Generate NDPA-compliant privacy policy for your organization as NDPA Section 24 talk am.',
+    previewTitle: 'Privacy Policy Preview',
+    previewDescription: 'Preview your NDPA-compliant privacy policy before you export am.',
+    exporterTitle: 'Privacy Policy',
+    exporterDescription: 'Export your NDPA-compliant privacy policy for different formats.',
+    wizardTitle: 'Privacy Policy Builder',
+  },
+  lawfulBasis: {
+    title: 'Lawful Basis Tracker',
+    description: 'Document and track the lawful basis for each processing activity as NDPA 2023 Section 25 talk am.',
+  },
+  crossBorder: {
+    title: 'Cross-Border Data Transfer Manager',
+    description: 'Manage and document cross-border personal data transfers as NDPA 2023 Part VIII (Sections 41-43) talk am.',
+  },
+  ropa: {
+    title: 'Record of Processing Activities (ROPA)',
+    description: 'Keep comprehensive record of all data processing activities as the NDPA accountability principle talk am.',
   },
   compliance: {
     score: 'Compliance Score',

--- a/packages/ndpr-toolkit/src/locales/yo.ts
+++ b/packages/ndpr-toolkit/src/locales/yo.ts
@@ -14,6 +14,9 @@ export const yorubaLocale: Required<{
     deselectAll: 'Yọ Gbogbo Kúrò',
     required: 'Kò Ṣe Yẹra Fún',
     cookieNotice: 'Nípa títẹ "Gba Gbogbo", o fohùn ṣọ̀kan pẹ̀lú lílo gbogbo kúkì. Ṣàbẹ̀wò Ìlànà Kúkì wa láti kẹ́kọ̀ọ́ síi.',
+    managerTitle: 'Ṣàkóso Àwọn Ètò Àṣírí Rẹ',
+    managerDescription: 'Ṣàtúnṣe àwọn àṣàyàn ìfohùnṣọ̀kan rẹ nígbàkigbà. A kò lè pa àwọn kúkì tí a nílò mọ́ nítorí pé wọ́n ṣe pàtàkì fún ìṣiṣẹ́ wẹ́ẹ̀bùsáìtì. A ń pèsè ìṣàkóso ìfohùnṣọ̀kan gẹ́gẹ́ bí Abala 25-26 ti NDPA.',
+    resetToDefaults: 'Tún Padà sí Àpapọ̀',
   },
   dsr: {
     title: 'Fi Ìbéèrè Oní-dátà Sílẹ̀',
@@ -30,6 +33,10 @@ export const yorubaLocale: Required<{
     identifierValue: 'Iye Ìdánimọ̀',
     privacyNotice: 'Àwọn ìròyìn tí o bá pèsè nínú fọ́ọ̀mù yìí ni a ó lò fún ète ṣíṣe àbójútó ìbéèrè oní-dátà rẹ nìkan.',
     successMessage: 'A ti fi ìbéèrè rẹ sílẹ̀ dáradára.',
+    dashboardTitle: 'Pápá Iṣẹ́ Ìbéèrè Oní-dátà',
+    dashboardDescription: 'Tọpa àti ṣàkóso àwọn ìbéèrè oní-dátà gẹ́gẹ́ bí ìbéèrè NDPA Apá Kẹrin.',
+    trackerTitle: 'Olùtọpa Ìbéèrè DSR',
+    trackerDescription: 'Tọpa ipò àti ìlọsíwájú àwọn ìbéèrè oní-dátà gẹ́gẹ́ bí NDPA Apá Kẹrin béèrè.',
   },
   breach: {
     title: 'Ṣe Ìròyìn Ìrúfin Dátà',
@@ -39,6 +46,12 @@ export const yorubaLocale: Required<{
     category: 'Ẹ̀ka',
     discoveredAt: 'Ọjọ́ Tí A Rí I',
     detailedDescription: 'Àlàyé Kíkún',
+    riskAssessmentTitle: 'Ìgbéléwọ̀n Ewu Ìrúfin',
+    riskAssessmentDescription: 'Ṣe ìgbéléwọ̀n ipele ewu ti ìrúfin dátà yìí láti pinnu ìbéèrè ìfitónilétí lábẹ́ Abala 40 NDPA.',
+    notificationManagerTitle: 'Olùṣàkóso Ìfitónilétí Ìrúfin',
+    notificationManagerDescription: 'Ṣàkóso àwọn ìfitónilétí ìrúfin dátà àti tọpa ìbámu pẹ̀lú àwọn ìbéèrè Abala 40 NDPA.',
+    regulatoryReportTitle: 'Ṣẹ̀dá Àkójọ Ìfitónilétí NDPC',
+    regulatoryReportDescription: 'Ṣẹ̀dá àkójọ fún ìfisíhàn sí NDPC ní ìbámu pẹ̀lú àwọn ìbéèrè ìfitónilétí ìrúfin Abala 40 NDPA.',
   },
   dpia: {
     title: 'Ìgbéléwọ̀n Ipa Ìdáàbòbò Dátà',
@@ -46,6 +59,8 @@ export const yorubaLocale: Required<{
     previous: 'Sẹ́yìn',
     complete: 'Parí Ìgbéléwọ̀n',
     progress: 'Ìlọsíwájú',
+    submit: 'Fi Sílẹ̀',
+    reportTitle: 'Àkójọ Ìgbéléwọ̀n Ipa Ìdáàbòbò Dátà',
   },
   policy: {
     title: 'Olùpilẹ̀ṣẹ̀ Ìlànà Àṣírí',
@@ -54,6 +69,25 @@ export const yorubaLocale: Required<{
     export: 'Gbé Jáde',
     sections: 'Àwọn Abala',
     variables: 'Àwọn Oníyípadà',
+    generatorTitle: 'Olùpilẹ̀ṣẹ̀ Ìlànà Àṣírí NDPA',
+    generatorDescription: 'Ṣẹ̀dá ìlànà àṣírí tí ó bá NDPA mu fún àjọ rẹ ní ìbámu pẹ̀lú Abala 24 NDPA.',
+    previewTitle: 'Àyẹ̀wò Ìlànà Àṣírí',
+    previewDescription: 'Yẹ ìlànà àṣírí rẹ tí ó bá NDPA mu wo ṣáájú gbígbé jáde.',
+    exporterTitle: 'Ìlànà Àṣírí',
+    exporterDescription: 'Gbé ìlànà àṣírí rẹ tí ó bá NDPA mu jáde ní oríṣiríṣi ọ̀nà.',
+    wizardTitle: 'Olùkọ́ Ìlànà Àṣírí',
+  },
+  lawfulBasis: {
+    title: 'Olùtọpa Ìpilẹ̀ Òfin',
+    description: 'Ṣe àkọsílẹ̀ àti tọpa ìpilẹ̀ òfin fún iṣẹ́ ṣíṣe ìṣàkóso kọ̀ọ̀kan gẹ́gẹ́ bí Abala 25 NDPA 2023 béèrè.',
+  },
+  crossBorder: {
+    title: 'Olùṣàkóso Gbígbé Dátà Kọjá-Ààlà',
+    description: 'Ṣàkóso àti ṣe àkọsílẹ̀ gbígbé dátà oníra ẹnìkọ̀ọ̀kan kọjá-ààlà ní ìbámu pẹ̀lú NDPA 2023 Apá Kẹjọ (Abala 41-43).',
+  },
+  ropa: {
+    title: 'Àkọsílẹ̀ Àwọn Iṣẹ́ Ìṣàkóso (ROPA)',
+    description: 'Pa àkọsílẹ̀ kíkún ti gbogbo iṣẹ́ ṣíṣe ìṣàkóso dátà mọ́ gẹ́gẹ́ bí ìlànà ìjíhàn NDPA béèrè.',
   },
   compliance: {
     score: 'Àmì Ìbámu',

--- a/packages/ndpr-toolkit/src/presets/NDPRBreachReport.tsx
+++ b/packages/ndpr-toolkit/src/presets/NDPRBreachReport.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { BreachReportForm } from '../components/breach/BreachReportForm';
 import type { BreachReportFormClassNames, BreachFormSubmission } from '../components/breach/BreachReportForm';
 import type { BreachCategory } from '../types/breach';
@@ -37,12 +37,88 @@ const DEFAULT_CATEGORIES: BreachCategory[] = [
   },
 ];
 
+/**
+ * UX copy overrides for the NDPRBreachReport preset. Pass any subset to
+ * replace the default text without dropping to the lower-level
+ * `<BreachReportForm>` API.
+ */
+export interface NDPRBreachReportCopy {
+  /** Form heading. Default: "Report a Data Breach" */
+  title?: string;
+  /** Body paragraph under the heading. */
+  description?: string;
+  /** Submit button label. Default: "Submit Report" */
+  submitButton?: string;
+}
+
 export interface NDPRBreachReportProps {
   categories?: BreachCategory[];
   adapter?: StorageAdapter<BreachFormSubmission>;
   classNames?: BreachReportFormClassNames;
   unstyled?: boolean;
   onSubmit?: (data: BreachFormSubmission) => void;
+
+  /**
+   * UX copy overrides — see {@link NDPRBreachReportCopy}.
+   */
+  copy?: NDPRBreachReportCopy;
+
+  /**
+   * @deprecated Renamed to `copy.description`. Will be removed in 4.0.
+   * If both are set, `copy.description` wins.
+   */
+  formDescription?: string;
+
+  /**
+   * Body paragraph under the heading. Canonical name in 3.13+. Takes
+   * precedence over `formDescription`.
+   */
+  description?: string;
+
+  /**
+   * Public-form mode. Use when the form should submit to your existing
+   * backend workflow instead of being state-managed by an adapter.
+   *
+   * When `submitTo` is set:
+   * - the form does NOT require an `adapter`
+   * - on submit, the toolkit POSTs the JSON-serialised `BreachFormSubmission`
+   *   to this URL (with `Content-Type: application/json`)
+   * - your `onSubmit` callback still fires (after the POST resolves)
+   * - submit failures are surfaced via `onSubmitError`
+   *
+   * @example
+   *   <NDPRBreachReport submitTo="/api/breach" />
+   */
+  submitTo?: string;
+
+  /**
+   * Fetch options for the `submitTo` POST. Useful for adding `credentials`
+   * (cookies/auth), `X-CSRF-Token`, or any other header your backend
+   * requires. Ignored unless `submitTo` is set.
+   *
+   * @default { credentials: 'same-origin' }
+   */
+  submitOptions?: {
+    headers?: Record<string, string> | (() => Record<string, string>);
+    credentials?: RequestCredentials;
+  };
+
+  /**
+   * Called when a `submitTo` POST fails (network error or non-2xx
+   * response). Receives the underlying error or Response.
+   */
+  onSubmitError?: (ctx: { error?: unknown; response?: Response }) => void;
+
+  /**
+   * Called when a `submitTo` POST succeeds (2xx response). Receives the
+   * `Response` object, the submitted `BreachFormSubmission` payload, and the
+   * parsed JSON body if the server returned valid JSON.
+   */
+  onSubmitSuccess?: (ctx: {
+    response: Response;
+    data: BreachFormSubmission;
+    body?: unknown;
+  }) => void;
 }
 
 export const NDPRBreachReport: React.FC<NDPRBreachReportProps> = ({
@@ -51,11 +127,66 @@ export const NDPRBreachReport: React.FC<NDPRBreachReportProps> = ({
   classNames,
   unstyled,
   onSubmit = () => {},
+  copy,
+  formDescription,
+  description,
+  submitTo,
+  submitOptions,
+  onSubmitError,
+  onSubmitSuccess,
 }) => {
-  const handleSubmit = (data: BreachFormSubmission) => {
-    if (adapter) adapter.save(data);
+  // Deprecation warning for `formDescription` — dev only, fire-once per instance.
+  const warnedFormDescriptionRef = useRef(false);
+  useEffect(() => {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      formDescription !== undefined &&
+      description === undefined &&
+      !warnedFormDescriptionRef.current
+    ) {
+      warnedFormDescriptionRef.current = true;
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[ndpr-toolkit/breach] NDPRBreachReportProps.formDescription is deprecated; rename to 'description'. Will be removed in 4.0.",
+      );
+    }
+  }, [formDescription, description]);
+
+  const handleSubmit = async (data: BreachFormSubmission) => {
+    if (submitTo) {
+      const headers = typeof submitOptions?.headers === 'function'
+        ? submitOptions.headers()
+        : submitOptions?.headers ?? {};
+      try {
+        const response = await fetch(submitTo, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...headers },
+          credentials: submitOptions?.credentials ?? 'same-origin',
+          body: JSON.stringify(data),
+        });
+        if (!response.ok) {
+          onSubmitError?.({ response });
+        } else if (onSubmitSuccess) {
+          let body: unknown;
+          try {
+            const text = await response.clone().text();
+            if (text) body = JSON.parse(text);
+          } catch {
+            // body wasn't JSON
+          }
+          onSubmitSuccess({ response, data, body });
+        }
+      } catch (error) {
+        onSubmitError?.({ error });
+      }
+    } else if (adapter) {
+      adapter.save(data);
+    }
     onSubmit(data);
   };
+
+  // description (new) wins; copy.description wins over both forms; formDescription is legacy.
+  const resolvedDescription = copy?.description ?? description ?? formDescription;
 
   return (
     <BreachReportForm
@@ -63,6 +194,9 @@ export const NDPRBreachReport: React.FC<NDPRBreachReportProps> = ({
       onSubmit={handleSubmit}
       classNames={classNames}
       unstyled={unstyled}
+      title={copy?.title}
+      formDescription={resolvedDescription}
+      submitButtonText={copy?.submitButton}
     />
   );
 };

--- a/packages/ndpr-toolkit/src/presets/NDPRConsent.tsx
+++ b/packages/ndpr-toolkit/src/presets/NDPRConsent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { ConsentBanner } from '../components/consent/ConsentBanner';
 import type { ConsentBannerClassNames } from '../components/consent/ConsentBanner';
 import type { ConsentOption, ConsentSettings } from '../types/consent';
@@ -56,10 +56,27 @@ export interface NDPRConsentProps {
 }
 
 export const NDPRConsent: React.FC<NDPRConsentProps> = ({
-  extraOptions = [], options, adapter, position = 'bottom',
+  extraOptions, options, adapter, position = 'bottom',
   classNames, unstyled, onSave, copy,
 }) => {
-  const resolvedOptions = options ?? [...DEFAULT_OPTIONS, ...extraOptions];
+  // Dev-only deprecation warning: `extraOptions` is a one-off pattern.
+  // Pass the full options array via `options` instead.
+  const warnedExtraOptionsRef = useRef(false);
+  useEffect(() => {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      extraOptions !== undefined &&
+      !warnedExtraOptionsRef.current
+    ) {
+      warnedExtraOptionsRef.current = true;
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[ndpr-toolkit/consent] NDPRConsentProps.extraOptions is deprecated; pass the full options array via 'options' instead. Will be removed in 4.0.",
+      );
+    }
+  }, [extraOptions]);
+
+  const resolvedOptions = options ?? [...DEFAULT_OPTIONS, ...(extraOptions ?? [])];
   const handleSave = (settings: ConsentSettings) => {
     if (adapter) adapter.save(settings);
     onSave?.(settings);

--- a/packages/ndpr-toolkit/src/presets/NDPRCrossBorder.tsx
+++ b/packages/ndpr-toolkit/src/presets/NDPRCrossBorder.tsx
@@ -1,22 +1,72 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { CrossBorderTransferManager } from '../components/cross-border/CrossBorderTransferManager';
 import type { CrossBorderTransferManagerClassNames } from '../components/cross-border/CrossBorderTransferManager';
 import type { CrossBorderTransfer } from '../types/cross-border';
 import type { StorageAdapter } from '../adapters/types';
 
+/**
+ * UX copy overrides for the NDPRCrossBorder preset. Pass any subset to
+ * replace the default text without dropping to the lower-level
+ * `<CrossBorderTransferManager>` API.
+ */
+export interface NDPRCrossBorderCopy {
+  /** Manager heading. Default: "Cross-Border Data Transfer Manager" */
+  title?: string;
+  /** Body paragraph under the heading. */
+  description?: string;
+}
+
 export interface NDPRCrossBorderProps {
+  /**
+   * Initial transfers to seed the manager. Canonical name in 3.13+.
+   * Takes precedence over `initialTransfers` if both are set.
+   */
+  initialData?: CrossBorderTransfer[];
+
+  /**
+   * @deprecated Renamed to `initialData`. Will be removed in 4.0.
+   * If both are set, `initialData` wins.
+   */
   initialTransfers?: CrossBorderTransfer[];
+
   adapter?: StorageAdapter<CrossBorderTransfer[]>;
   classNames?: CrossBorderTransferManagerClassNames;
   unstyled?: boolean;
+
+  /**
+   * UX copy overrides — see {@link NDPRCrossBorderCopy}.
+   */
+  copy?: NDPRCrossBorderCopy;
 }
 
 export const NDPRCrossBorder: React.FC<NDPRCrossBorderProps> = ({
-  initialTransfers = [],
+  initialData,
+  initialTransfers,
   adapter,
   classNames,
   unstyled,
+  copy,
 }) => {
+  // Dev-only deprecation warning: `initialTransfers` is the 3.x name;
+  // `initialData` is the canonical 3.13+ name. Fire-once per instance.
+  const warnedInitialTransfersRef = useRef(false);
+  useEffect(() => {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      initialTransfers !== undefined &&
+      initialData === undefined &&
+      !warnedInitialTransfersRef.current
+    ) {
+      warnedInitialTransfersRef.current = true;
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[ndpr-toolkit/cross-border] NDPRCrossBorderProps.initialTransfers is deprecated; rename to 'initialData'. Will be removed in 4.0.",
+      );
+    }
+  }, [initialTransfers, initialData]);
+
+  const resolvedInitial: CrossBorderTransfer[] = initialData ?? initialTransfers ?? [];
+
   // Synchronous seed: only honoured for sync adapters (localStorage,
   // memory). Async adapters (cookie, api) return a Promise which we ignore
   // here and rehydrate via the effect below.
@@ -25,7 +75,7 @@ export const NDPRCrossBorder: React.FC<NDPRCrossBorderProps> = ({
       const saved = adapter.load();
       if (saved && !(saved instanceof Promise)) return saved;
     }
-    return initialTransfers;
+    return resolvedInitial;
   });
 
   // Async hydrate: covers cookieAdapter / apiAdapter / any adapter that
@@ -88,6 +138,8 @@ export const NDPRCrossBorder: React.FC<NDPRCrossBorderProps> = ({
       onRemoveTransfer={handleRemoveTransfer}
       classNames={classNames}
       unstyled={unstyled}
+      title={copy?.title}
+      description={copy?.description}
     />
   );
 };

--- a/packages/ndpr-toolkit/src/presets/NDPRDPIA.tsx
+++ b/packages/ndpr-toolkit/src/presets/NDPRDPIA.tsx
@@ -5,6 +5,26 @@ import type { DPIASection } from '../types/dpia';
 import type { StorageAdapter } from '../adapters/types';
 import type { DPIAAnswerMap, DPIAAnswerValue } from '../hooks/useDPIA';
 
+/**
+ * UX copy overrides for the NDPRDPIA preset. Strings you omit fall back
+ * to the lower-level `<DPIAQuestionnaire>` defaults. The DPIA wizard does
+ * not render a single header (each section has its own title); the `title`
+ * and `description` fields are reserved for future use and currently
+ * accepted for API parity with the other presets.
+ */
+export interface NDPRDPIACopy {
+  /** Reserved — DPIA sections render their own titles. */
+  title?: string;
+  /** Reserved — DPIA sections render their own descriptions. */
+  description?: string;
+  /** Final-step submit button label. Default: "Submit" */
+  submitButton?: string;
+  /** Next-section button label. Default: "Next" */
+  nextButton?: string;
+  /** Previous-section button label. Default: "Previous" */
+  prevButton?: string;
+}
+
 const DEFAULT_SECTIONS: DPIASection[] = [
   {
     id: 'project_overview',
@@ -148,6 +168,56 @@ export interface NDPRDPIAProps {
   classNames?: DPIAQuestionnaireClassNames;
   unstyled?: boolean;
   onComplete?: (answers: DPIAAnswerMap) => void;
+
+  /**
+   * UX copy overrides — see {@link NDPRDPIACopy}.
+   */
+  copy?: NDPRDPIACopy;
+
+  /**
+   * Public-form mode. Use when the questionnaire should submit to your
+   * existing backend workflow instead of being state-managed by an adapter.
+   *
+   * When `submitTo` is set:
+   * - the questionnaire does NOT require an `adapter`
+   * - on completion, the toolkit POSTs the JSON-serialised `DPIAAnswerMap`
+   *   to this URL (with `Content-Type: application/json`)
+   * - your `onComplete` callback still fires (after the POST resolves)
+   * - submit failures are surfaced via `onSubmitError`
+   *
+   * @example
+   *   <NDPRDPIA submitTo="/api/dpia" />
+   */
+  submitTo?: string;
+
+  /**
+   * Fetch options for the `submitTo` POST. Useful for adding `credentials`
+   * (cookies/auth), `X-CSRF-Token`, or any other header your backend
+   * requires. Ignored unless `submitTo` is set.
+   *
+   * @default { credentials: 'same-origin' }
+   */
+  submitOptions?: {
+    headers?: Record<string, string> | (() => Record<string, string>);
+    credentials?: RequestCredentials;
+  };
+
+  /**
+   * Called when a `submitTo` POST fails (network error or non-2xx
+   * response).
+   */
+  onSubmitError?: (ctx: { error?: unknown; response?: Response }) => void;
+
+  /**
+   * Called when a `submitTo` POST succeeds (2xx response). Receives the
+   * `Response` object, the submitted `DPIAAnswerMap` payload, and the
+   * parsed JSON body if the server returned valid JSON.
+   */
+  onSubmitSuccess?: (ctx: {
+    response: Response;
+    data: DPIAAnswerMap;
+    body?: unknown;
+  }) => void;
 }
 
 export const NDPRDPIA: React.FC<NDPRDPIAProps> = ({
@@ -156,6 +226,11 @@ export const NDPRDPIA: React.FC<NDPRDPIAProps> = ({
   classNames,
   unstyled,
   onComplete = () => {},
+  copy,
+  submitTo,
+  submitOptions,
+  onSubmitError,
+  onSubmitSuccess,
 }) => {
   const [answers, setAnswers] = useState<DPIAAnswerMap>({});
   const [currentSectionIndex, setCurrentSectionIndex] = useState(0);
@@ -164,12 +239,44 @@ export const NDPRDPIA: React.FC<NDPRDPIAProps> = ({
     setAnswers(prev => ({ ...prev, [questionId]: value }));
   };
 
+  const finalizeSubmission = async (finalAnswers: DPIAAnswerMap) => {
+    if (submitTo) {
+      const headers = typeof submitOptions?.headers === 'function'
+        ? submitOptions.headers()
+        : submitOptions?.headers ?? {};
+      try {
+        const response = await fetch(submitTo, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...headers },
+          credentials: submitOptions?.credentials ?? 'same-origin',
+          body: JSON.stringify(finalAnswers),
+        });
+        if (!response.ok) {
+          onSubmitError?.({ response });
+        } else if (onSubmitSuccess) {
+          let body: unknown;
+          try {
+            const text = await response.clone().text();
+            if (text) body = JSON.parse(text);
+          } catch {
+            // body wasn't JSON
+          }
+          onSubmitSuccess({ response, data: finalAnswers, body });
+        }
+      } catch (error) {
+        onSubmitError?.({ error });
+      }
+    } else if (adapter) {
+      adapter.save(finalAnswers);
+    }
+    onComplete(finalAnswers);
+  };
+
   const handleNextSection = () => {
     if (currentSectionIndex < sections.length - 1) {
       setCurrentSectionIndex(prev => prev + 1);
     } else {
-      if (adapter) adapter.save(answers);
-      onComplete(answers);
+      void finalizeSubmission(answers);
     }
   };
 
@@ -192,6 +299,9 @@ export const NDPRDPIA: React.FC<NDPRDPIAProps> = ({
       progress={progress}
       classNames={classNames}
       unstyled={unstyled}
+      submitButtonText={copy?.submitButton}
+      nextButtonText={copy?.nextButton}
+      prevButtonText={copy?.prevButton}
     />
   );
 };

--- a/packages/ndpr-toolkit/src/presets/NDPRLawfulBasis.tsx
+++ b/packages/ndpr-toolkit/src/presets/NDPRLawfulBasis.tsx
@@ -1,22 +1,72 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { LawfulBasisTracker } from '../components/lawful-basis/LawfulBasisTracker';
 import type { LawfulBasisTrackerClassNames } from '../components/lawful-basis/LawfulBasisTracker';
 import type { ProcessingActivity } from '../types/lawful-basis';
 import type { StorageAdapter } from '../adapters/types';
 
+/**
+ * UX copy overrides for the NDPRLawfulBasis preset. Pass any subset to
+ * replace the default text without dropping to the lower-level
+ * `<LawfulBasisTracker>` API.
+ */
+export interface NDPRLawfulBasisCopy {
+  /** Tracker heading. Default: "Lawful Basis Tracker" */
+  title?: string;
+  /** Body paragraph under the heading. */
+  description?: string;
+}
+
 export interface NDPRLawfulBasisProps {
+  /**
+   * Initial activities to seed the tracker. Canonical name in 3.13+.
+   * Takes precedence over `initialActivities` if both are set.
+   */
+  initialData?: ProcessingActivity[];
+
+  /**
+   * @deprecated Renamed to `initialData`. Will be removed in 4.0.
+   * If both are set, `initialData` wins.
+   */
   initialActivities?: ProcessingActivity[];
+
   adapter?: StorageAdapter<ProcessingActivity[]>;
   classNames?: LawfulBasisTrackerClassNames;
   unstyled?: boolean;
+
+  /**
+   * UX copy overrides — see {@link NDPRLawfulBasisCopy}.
+   */
+  copy?: NDPRLawfulBasisCopy;
 }
 
 export const NDPRLawfulBasis: React.FC<NDPRLawfulBasisProps> = ({
-  initialActivities = [],
+  initialData,
+  initialActivities,
   adapter,
   classNames,
   unstyled,
+  copy,
 }) => {
+  // Dev-only deprecation warning: `initialActivities` is the 3.x name;
+  // `initialData` is the canonical 3.13+ name. Fire-once per instance.
+  const warnedInitialActivitiesRef = useRef(false);
+  useEffect(() => {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      initialActivities !== undefined &&
+      initialData === undefined &&
+      !warnedInitialActivitiesRef.current
+    ) {
+      warnedInitialActivitiesRef.current = true;
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[ndpr-toolkit/lawful-basis] NDPRLawfulBasisProps.initialActivities is deprecated; rename to 'initialData'. Will be removed in 4.0.",
+      );
+    }
+  }, [initialActivities, initialData]);
+
+  const resolvedInitial: ProcessingActivity[] = initialData ?? initialActivities ?? [];
+
   // Synchronous seed: only honoured for sync adapters (localStorage,
   // memory). Async adapters (cookie, api) return a Promise which we ignore
   // here and rehydrate via the effect below.
@@ -25,7 +75,7 @@ export const NDPRLawfulBasis: React.FC<NDPRLawfulBasisProps> = ({
       const saved = adapter.load();
       if (saved && !(saved instanceof Promise)) return saved;
     }
-    return initialActivities;
+    return resolvedInitial;
   });
 
   // Async hydrate: covers cookieAdapter / apiAdapter / any adapter that
@@ -90,6 +140,8 @@ export const NDPRLawfulBasis: React.FC<NDPRLawfulBasisProps> = ({
       onArchiveActivity={handleArchiveActivity}
       classNames={classNames}
       unstyled={unstyled}
+      title={copy?.title}
+      description={copy?.description}
     />
   );
 };

--- a/packages/ndpr-toolkit/src/presets/NDPRPrivacyPolicy.tsx
+++ b/packages/ndpr-toolkit/src/presets/NDPRPrivacyPolicy.tsx
@@ -9,11 +9,35 @@ import {
   type OrgPolicyTemplateOverrides,
 } from '../utils/policy-templates-orgs';
 
+/**
+ * UX copy overrides for the NDPRPrivacyPolicy preset. Strings you omit
+ * fall back to the underlying `<AdaptivePolicyWizard>` defaults.
+ *
+ * Note: the wizard renders many step-specific labels; the fields here
+ * cover the high-level header text. Step-specific copy is wired through
+ * the `NDPRProvider` locale.
+ */
+export interface NDPRPrivacyPolicyCopy {
+  /** Wizard heading. Default: "Privacy Policy Builder" */
+  title?: string;
+  /** Optional body paragraph under the heading. */
+  description?: string;
+  /** Submit / complete button label. */
+  submitButton?: string;
+}
+
 export interface NDPRPrivacyPolicyProps {
   adapter?: StorageAdapter<PolicyDraft>;
   onComplete?: (policy: PrivacyPolicy) => void;
   classNames?: Record<string, string>;
   unstyled?: boolean;
+
+  /**
+   * UX copy overrides — see {@link NDPRPrivacyPolicyCopy}. The wizard
+   * derives most of its labels from the active `NDPRProvider` locale; the
+   * fields here cover the high-level header text.
+   */
+  copy?: NDPRPrivacyPolicyCopy;
 
   /**
    * Pre-fill the policy wizard with a sector-specific starter template.
@@ -52,6 +76,10 @@ export const NDPRPrivacyPolicy: React.FC<NDPRPrivacyPolicyProps> = ({
   template,
   templateOverrides,
   initialContext,
+  // `copy` is consumed by the preset for forward compatibility — the
+  // underlying wizard currently derives most of its labels from the
+  // `NDPRProvider` locale, so this is an API stub for the 4.0 line.
+  copy: _copy,
   ...rest
 }) => {
   // Compute the seed context once. If `initialContext` is supplied we

--- a/packages/ndpr-toolkit/src/presets/NDPRROPA.tsx
+++ b/packages/ndpr-toolkit/src/presets/NDPRROPA.tsx
@@ -14,11 +14,28 @@ const DEFAULT_ROPA: RecordOfProcessingActivities = {
   version: '1.0',
 };
 
+/**
+ * UX copy overrides for the NDPRROPA preset. Pass any subset to
+ * replace the default text without dropping to the lower-level
+ * `<ROPAManager>` API.
+ */
+export interface NDPRROPACopy {
+  /** Manager heading. Default: "Record of Processing Activities (ROPA)" */
+  title?: string;
+  /** Body paragraph under the heading. */
+  description?: string;
+}
+
 export interface NDPRROPAProps {
   initialData?: RecordOfProcessingActivities;
   adapter?: StorageAdapter<RecordOfProcessingActivities>;
   classNames?: ROPAManagerClassNames;
   unstyled?: boolean;
+
+  /**
+   * UX copy overrides — see {@link NDPRROPACopy}.
+   */
+  copy?: NDPRROPACopy;
 }
 
 export const NDPRROPA: React.FC<NDPRROPAProps> = ({
@@ -26,6 +43,7 @@ export const NDPRROPA: React.FC<NDPRROPAProps> = ({
   adapter,
   classNames,
   unstyled,
+  copy,
 }) => {
   const [ropa, setRopa] = useState<RecordOfProcessingActivities>(initialData ?? DEFAULT_ROPA);
 
@@ -86,6 +104,8 @@ export const NDPRROPA: React.FC<NDPRROPAProps> = ({
       onArchiveRecord={handleArchiveRecord}
       classNames={classNames}
       unstyled={unstyled}
+      title={copy?.title}
+      description={copy?.description}
     />
   );
 };

--- a/packages/ndpr-toolkit/src/presets/index.ts
+++ b/packages/ndpr-toolkit/src/presets/index.ts
@@ -1,26 +1,26 @@
 export { NDPRConsent } from './NDPRConsent';
-export type { NDPRConsentProps } from './NDPRConsent';
+export type { NDPRConsentProps, NDPRConsentCopy } from './NDPRConsent';
 
 export { NDPRSubjectRights } from './NDPRSubjectRights';
 export type { NDPRSubjectRightsProps } from './NDPRSubjectRights';
 
 export { NDPRBreachReport } from './NDPRBreachReport';
-export type { NDPRBreachReportProps } from './NDPRBreachReport';
+export type { NDPRBreachReportProps, NDPRBreachReportCopy } from './NDPRBreachReport';
 
 export { NDPRPrivacyPolicy } from './NDPRPrivacyPolicy';
-export type { NDPRPrivacyPolicyProps } from './NDPRPrivacyPolicy';
+export type { NDPRPrivacyPolicyProps, NDPRPrivacyPolicyCopy } from './NDPRPrivacyPolicy';
 
 export { NDPRDPIA } from './NDPRDPIA';
-export type { NDPRDPIAProps } from './NDPRDPIA';
+export type { NDPRDPIAProps, NDPRDPIACopy } from './NDPRDPIA';
 
 export { NDPRLawfulBasis } from './NDPRLawfulBasis';
-export type { NDPRLawfulBasisProps } from './NDPRLawfulBasis';
+export type { NDPRLawfulBasisProps, NDPRLawfulBasisCopy } from './NDPRLawfulBasis';
 
 export { NDPRCrossBorder } from './NDPRCrossBorder';
-export type { NDPRCrossBorderProps } from './NDPRCrossBorder';
+export type { NDPRCrossBorderProps, NDPRCrossBorderCopy } from './NDPRCrossBorder';
 
 export { NDPRROPA } from './NDPRROPA';
-export type { NDPRROPAProps } from './NDPRROPA';
+export type { NDPRROPAProps, NDPRROPACopy } from './NDPRROPA';
 
 export { NDPRDashboard as NDPRComplianceDashboard } from './NDPRDashboard';
 export type { NDPRDashboardPresetProps } from './NDPRDashboard';

--- a/packages/ndpr-toolkit/src/types/locale.ts
+++ b/packages/ndpr-toolkit/src/types/locale.ts
@@ -14,6 +14,12 @@ export interface NDPRLocale {
     deselectAll?: string;
     required?: string;
     cookieNotice?: string;
+    /** ConsentManager component title */
+    managerTitle?: string;
+    /** ConsentManager component description */
+    managerDescription?: string;
+    /** ConsentManager reset button */
+    resetToDefaults?: string;
   };
   dsr?: {
     title?: string;
@@ -30,6 +36,14 @@ export interface NDPRLocale {
     identifierValue?: string;
     privacyNotice?: string;
     successMessage?: string;
+    /** DSRDashboard component title */
+    dashboardTitle?: string;
+    /** DSRDashboard component description */
+    dashboardDescription?: string;
+    /** DSRTracker component title */
+    trackerTitle?: string;
+    /** DSRTracker component description */
+    trackerDescription?: string;
   };
   breach?: {
     title?: string;
@@ -39,6 +53,18 @@ export interface NDPRLocale {
     category?: string;
     discoveredAt?: string;
     detailedDescription?: string;
+    /** BreachRiskAssessment component title */
+    riskAssessmentTitle?: string;
+    /** BreachRiskAssessment component description */
+    riskAssessmentDescription?: string;
+    /** BreachNotificationManager component title */
+    notificationManagerTitle?: string;
+    /** BreachNotificationManager component description */
+    notificationManagerDescription?: string;
+    /** RegulatoryReportGenerator component title */
+    regulatoryReportTitle?: string;
+    /** RegulatoryReportGenerator component description */
+    regulatoryReportDescription?: string;
   };
   dpia?: {
     title?: string;
@@ -46,6 +72,10 @@ export interface NDPRLocale {
     previous?: string;
     complete?: string;
     progress?: string;
+    /** DPIAQuestionnaire submit button (last section) */
+    submit?: string;
+    /** DPIAReport main report title */
+    reportTitle?: string;
   };
   policy?: {
     title?: string;
@@ -54,6 +84,38 @@ export interface NDPRLocale {
     export?: string;
     sections?: string;
     variables?: string;
+    /** PolicyGenerator component title */
+    generatorTitle?: string;
+    /** PolicyGenerator component description */
+    generatorDescription?: string;
+    /** PolicyPreview component title */
+    previewTitle?: string;
+    /** PolicyPreview component description */
+    previewDescription?: string;
+    /** PolicyExporter component title */
+    exporterTitle?: string;
+    /** PolicyExporter component description */
+    exporterDescription?: string;
+    /** AdaptivePolicyWizard heading */
+    wizardTitle?: string;
+  };
+  lawfulBasis?: {
+    /** LawfulBasisTracker title */
+    title?: string;
+    /** LawfulBasisTracker description */
+    description?: string;
+  };
+  crossBorder?: {
+    /** CrossBorderTransferManager title */
+    title?: string;
+    /** CrossBorderTransferManager description */
+    description?: string;
+  };
+  ropa?: {
+    /** ROPAManager title */
+    title?: string;
+    /** ROPAManager description */
+    description?: string;
   };
   compliance?: {
     score?: string;


### PR DESCRIPTION
Release 5 of 6 on the post-audit roadmap. The **deprecation-window minor** — strictly additive, but every prop alias and behaviour change 4.0 will commit to fires here as a dev-mode warning. Existing consumers see no breakage.

## i18n is real now

\`useNDPRLocale\` wired into 17+ components (was 3 of 20 post-3.10.4). Every component now honours \`<NDPRProvider locale={…}>\` — the docs claim is no longer a lie. Locale type expanded; all 5 shipped locales got new keys. **21 new i18n tests** confirm.

## Preset API harmonization

- \`submitTo\` / \`onSubmitSuccess\` / \`onSubmitError\` lifted to \`NDPRBreachReport\` + \`NDPRDPIA\`.
- \`copy?\` prop + \`NDPR<Name>Copy\` interface on 6 presets.
- \`description\` alias on \`BreachReportForm\` (alongside \`formDescription\`).
- \`initialData\` alias on \`NDPRLawfulBasis\` / \`NDPRCrossBorder\`.

## Dev-only deprecation warns (queue for 4.0 removal)

- \`formDescription\` → \`description\`
- \`initialActivities\` / \`initialTransfers\` → \`initialData\`
- \`extraOptions\` → \`options\`
- \`useDSR\` localStorage default (4.0 switches to in-memory)

All guarded by \`NODE_ENV !== 'production'\` AND \`useRef\` fire-once.

## Test plan

- [x] Jest: 1258 / 1258 passing (was 1237 — +21 new i18n tests)
- [x] tsc --noEmit clean
- [x] pnpm verify:tarball clean across 22 subpaths