### PR TITLE
chore: 5.0.1 — docs-only patch to refresh the npm README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [5.0.1](https://github.com/mr-tanta/ndpr-toolkit/compare/v5.0.0...v5.0.1) (2026-05-28)
+
+Docs-only patch. No runtime code change.
+
+- README refresh for 5.0: structured-result validator examples (route-handler + client branching), new Internationalization section listing all seven shipped locales (en, yo, ig, ha, pcm, ar, fr) with RTL guidance, `/server` and `/core` import examples switched to `validateConsentStructured`, `cookieAdapter` default documented as 180 days with NDPA Section 26 rationale, and every `raw.githubusercontent.com/.../vN.N.N/...` image URL pinned to the v5.0.0 tag.
+
+The npm page now matches the v5 surface. No code, types, or exports changed — `^5.0.0` consumers do not need to upgrade unless they want the new README on their npm page.
+
 ## [5.0.0](https://github.com/mr-tanta/ndpr-toolkit/compare/v4.1.0...v5.0.0) (2026-05-27)
 
 Closes the deprecation window opened by 4.1.0. Every removal here was already deprecated and dev-warned in 4.1, so if your 4.1.x dev console was clean, your 5.0 upgrade is a one-line bump. Full migration table in [`/docs/guides/migrating-4-1-to-5-0`](https://ndprtoolkit.com.ng/docs/guides/migrating-4-1-to-5-0).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tantainnovative/ndpr-toolkit",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": false,
   "description": "Nigeria Data Protection Toolkit — enterprise-grade compliance components for the Nigeria Data Protection Act (NDPA) 2023",
   "pnpm": {

--- a/packages/ndpr-toolkit/package.json
+++ b/packages/ndpr-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tantainnovative/ndpr-toolkit",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "description": "React and TypeScript compliance components for the Nigeria Data Protection Act (NDPA) 2023. NOTE: This inner package.json is NOT published — `npm publish` runs from the repo root. Marked `private: true` since 3.10.5 to make that explicit and prevent the drift class that caused the 3.8.0–3.10.2 missing-exports incident. Slated for removal in 4.0 (see plan: clear-the-audit-backlog).",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Cut a docs-only patch so the next publish workflow refreshes the rendered README on the npm package page. The README on npm right now is the snapshot taken at v5.0.0 publish time, which still carries the pre-5.0 'what's new' callout and the legacy validator import examples (PR #64 updated `main` after v5.0.0 had already been published, so npm didn't pick it up).

No code, types, or exports changed. `^5.0.0` consumers do not need to upgrade unless they want the new README on their npm page.

## Test plan

- [x] No `src/` diff — `package.json` version bumps + `CHANGELOG.md` entry only
- [ ] CI green
- [ ] After merge + tag + release, confirm `npm view @tantainnovative/ndpr-toolkit readme` returns the new content