### PR TITLE
feat: 5.1.0 — widen jspdf peer to ^3.0.3 || ^4.2.1 for the CVE fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [5.1.0](https://github.com/mr-tanta/ndpr-toolkit/compare/v5.0.1...v5.1.0) (2026-05-28)
+
+Security hygiene for the optional PDF-export peer. No change to the toolkit's own code — peer range + docs only.
+
+### Changed
+
+- **`jspdf` peer range widened: `^3.0.3` → `^3.0.3 || ^4.2.1`.** jspdf ≤ 4.2.0 carries three advisories — `GHSA-67pg-wm7f-q7fj` (High, CVSS 8.7: `addImage` GIF out-of-memory DoS), `GHSA-cjw8-79x6-5cj4` (Medium: `addJS` shared-state cross-user data leakage in concurrent server-side use), and a Critical path-traversal/LFI item. jspdf **4.2.1** clears all of them (`npm audit`: 0 vulnerabilities). The old `^3.0.3` peer pinned consumers to vulnerable 3.x; the widened range lets them install the patched 4.2.1+.
+
+  The toolkit's `exportPDF` only uses core jsPDF text/vector primitives — it never calls `addImage`, `addJS`, or `.html()` — so the toolkit's own PDF path was never a sink for these CVEs. The bump is for consumers who install jspdf and want a clean audit. jspdf stays an **optional** peer (dynamic `import('jspdf')`); consumers who don't export PDFs never install it.
+
+### Docs
+
+- README + `exportPDF` JSDoc now note that PDF export needs **jspdf ≥ 4.2.1**, and that installing it with `--omit=optional` (npm) / `--no-optional` (pnpm) drops jspdf's optional deps (`canvg`, `core-js`, `dompurify`, `html2canvas`) for a dependency-free PDF surface — the toolkit uses none of them.
+
+### Verification
+
+- `npm audit` against `jspdf@4.2.1` — 0 vulnerabilities
+- `pnpm jest --no-coverage`, `pnpm verify:tarball`, `npx tsc --noEmit -p tsconfig.json` — all green
+
 ## [5.0.1](https://github.com/mr-tanta/ndpr-toolkit/compare/v5.0.0...v5.0.1) (2026-05-28)
 
 Docs-only patch. No runtime code change.

--- a/README.md
+++ b/README.md
@@ -654,7 +654,7 @@ Each component exports its `ClassNames` TypeScript interface for autocomplete. F
 | `/dsr` | DSR components + hook | `react` | No |
 | `/dpia` | DPIA components + hook | `react` | No |
 | `/breach` | Breach components + hook | `react` | No |
-| `/policy` | Policy components + hook | `react`, `jspdf`, `docx` (optional) | No |
+| `/policy` | Policy components + hook | `react`, `jspdf` ≥ 4.2.1, `docx` (both optional) | No |
 | `/lawful-basis` | Lawful basis component + hook | `react` | No |
 | `/lawful-basis/lite` | Read-only `LawfulBasisTrackerLite` — ~65% smaller than `/lawful-basis` | `react` | No |
 | `/cross-border` | Cross-border component + hook | `react` | No |
@@ -665,6 +665,17 @@ Each component exports its `ClassNames` TypeScript interface for autocomplete. F
 | `/styles` | Default CSS stylesheet — `import "@tantainnovative/ndpr-toolkit/styles"` once in your app entry | none | N/A |
 
 [^core]: `/core` re-exports the React `NDPRProvider` for backward compatibility. For strictly server-side imports use `/server` — it carries the same pure validators with no React surface.
+
+### PDF / DOCX export peers
+
+`PolicyExporter` (and `exportPDF` / `exportDOCX` from `/policy`) load `jspdf` / `docx` via dynamic `import()` only when you actually export — they're optional peers, so consumers who don't export documents never install them. If you do export to PDF:
+
+```bash
+npm install jspdf@^4.2.1 --omit=optional      # npm
+pnpm add jspdf@^4.2.1 --no-optional           # pnpm
+```
+
+Use **jspdf ≥ 4.2.1** — earlier versions (≤ 4.2.0) carry advisories `GHSA-67pg-wm7f-q7fj` and `GHSA-cjw8-79x6-5cj4`, fixed in 4.2.1. The `--omit=optional` / `--no-optional` flag drops jspdf's own optional deps (`canvg`, `core-js`, `dompurify`, `html2canvas`); the toolkit's PDF export uses only core jsPDF text/vector APIs, so it works without them and you get a leaner, dependency-flag-free install.
 
 ### Bundle size guidance
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tantainnovative/ndpr-toolkit",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "private": false,
   "description": "Nigeria Data Protection Toolkit — enterprise-grade compliance components for the Nigeria Data Protection Act (NDPA) 2023",
   "pnpm": {
@@ -303,7 +303,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "docx": ">=8.0.0",
-    "jspdf": "^3.0.3",
+    "jspdf": "^3.0.3 || ^4.2.1",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "tailwind-merge": "^2.6.0"

--- a/packages/ndpr-toolkit/package.json
+++ b/packages/ndpr-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tantainnovative/ndpr-toolkit",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "private": true,
   "description": "React and TypeScript compliance components for the Nigeria Data Protection Act (NDPA) 2023. NOTE: This inner package.json is NOT published — `npm publish` runs from the repo root. Marked `private: true` since 3.10.5 to make that explicit and prevent the drift class that caused the 3.8.0–3.10.2 missing-exports incident. Slated for removal in 4.0 (see plan: clear-the-audit-backlog).",
   "main": "./dist/index.js",
@@ -257,7 +257,7 @@
   },
   "peerDependencies": {
     "docx": ">=8.0.0",
-    "jspdf": ">=2.5.0",
+    "jspdf": "^3.0.3 || ^4.2.1",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },

--- a/packages/ndpr-toolkit/src/utils/policy-export/pdf.ts
+++ b/packages/ndpr-toolkit/src/utils/policy-export/pdf.ts
@@ -5,6 +5,11 @@ import { LEGAL_DISCLAIMER_LONG } from '../legal-notice';
 /**
  * Export a PrivacyPolicy to a PDF Blob using jspdf (optional peer dependency).
  *
+ * Requires jspdf >= 4.2.1 (earlier versions carry GHSA-67pg-wm7f-q7fj and
+ * GHSA-cjw8-79x6-5cj4). This function uses only core jsPDF text/vector APIs —
+ * never `addImage`, `addJS`, or `.html()` — so jspdf's optional deps
+ * (canvg, core-js, dompurify, html2canvas) can be omitted (`--omit=optional`).
+ *
  * Features:
  * - Optional cover page with title, organisation, date, version and compliance badge
  * - Optional table of contents page


### PR DESCRIPTION
## Summary

Security hygiene for the optional PDF-export peer. No change to the toolkit's own code — peer range + docs only.

`jspdf` ≤ 4.2.0 carries three advisories surfaced by Socket/dependabot on the published package:
- **`GHSA-67pg-wm7f-q7fj`** (High, CVSS 8.7) — `addImage` GIF out-of-memory DoS
- **`GHSA-cjw8-79x6-5cj4`** (Medium) — `addJS` shared-state cross-user data leakage in concurrent server-side use
- a Critical path-traversal / LFI item

`jspdf@4.2.1` clears all of them (`npm audit`: 0 vulnerabilities). The old `^3.0.3` peer pinned consumers to vulnerable 3.x; this widens the range to `^3.0.3 || ^4.2.1` so they can install the patched version.

### Why the toolkit itself was never a sink

`exportPDF` uses only core jsPDF text/vector primitives — it never calls `addImage`, `addJS`, or `.html()` (verified: 0 occurrences in source). jspdf stays an **optional**, dynamically-imported peer, so consumers who don't export PDFs never install it. In jspdf 4.2.1 the heuristic-flagged packages (`canvg`, `core-js`, `dompurify`, `html2canvas`) are jspdf's own **optionalDependencies** — installing with `--omit=optional` drops them entirely for a clean, dependency-flag-free PDF surface, and the toolkit still works because it uses none of them.

### Docs

- README: `/policy` import-paths row annotated `jspdf ≥ 4.2.1`; new "PDF / DOCX export peers" section with the `--omit=optional` install.
- `exportPDF` JSDoc documents the ≥ 4.2.1 requirement and the safe-to-omit optional deps.

## Test plan

- [x] `npm audit` against `jspdf@4.2.1` — 0 vulnerabilities
- [x] `pnpm jest --no-coverage` — 1249 pass / 90 suites
- [x] `pnpm verify:tarball` — 22 subpaths resolve (5.1.0 tgz)
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [ ] CI green