### PR TITLE
fix: 5.1.1 — tighten jspdf peer to ^4.2.1 (drop vulnerable 3.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [5.1.1](https://github.com/mr-tanta/ndpr-toolkit/compare/v5.1.0...v5.1.1) (2026-05-28)
+
+Completes the jspdf security fix from 5.1.0.
+
+### Changed
+
+- **`jspdf` peer tightened: `^3.0.3 || ^4.2.1` → `^4.2.1`.** 5.1.0 widened the range but left `^3.0.3` in it — and *every* jspdf 3.x is vulnerable (the advisory is `<=4.2.0`; there is no safe 3.x). Keeping 3.x bought zero compatibility while letting a consumer satisfy the peer with a vulnerable `3.0.4`. Dropping it means the peer range now contains only patched versions, so a vulnerable jspdf can't satisfy it.
+
+  This narrows an **optional** peer range — technically breaking per semver, shipped as a patch because the removed versions are 100% vulnerable with no safe alternative and the toolkit's jspdf API usage (`new jsPDF(...)`, text/vector primitives) is identical across 3↔4. Consumers already on jspdf 4.2.1+ or not using PDF export are unaffected; consumers pinned to jspdf 3.x get a peer-range warning that correctly nudges them to the patched line.
+
+### Verification
+
+- `pnpm jest --no-coverage`, `pnpm verify:tarball`, `npx tsc --noEmit -p tsconfig.json` — all green
+- README + `exportPDF` JSDoc already specified jspdf ≥ 4.2.1 (5.1.0); no doc changes needed
+
 ## [5.1.0](https://github.com/mr-tanta/ndpr-toolkit/compare/v5.0.1...v5.1.0) (2026-05-28)
 
 Security hygiene for the optional PDF-export peer. No change to the toolkit's own code — peer range + docs only.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tantainnovative/ndpr-toolkit",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "private": false,
   "description": "Nigeria Data Protection Toolkit — enterprise-grade compliance components for the Nigeria Data Protection Act (NDPA) 2023",
   "pnpm": {
@@ -303,7 +303,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "docx": ">=8.0.0",
-    "jspdf": "^3.0.3 || ^4.2.1",
+    "jspdf": "^4.2.1",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "tailwind-merge": "^2.6.0"

--- a/packages/ndpr-toolkit/package.json
+++ b/packages/ndpr-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tantainnovative/ndpr-toolkit",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "private": true,
   "description": "React and TypeScript compliance components for the Nigeria Data Protection Act (NDPA) 2023. NOTE: This inner package.json is NOT published — `npm publish` runs from the repo root. Marked `private: true` since 3.10.5 to make that explicit and prevent the drift class that caused the 3.8.0–3.10.2 missing-exports incident. Slated for removal in 4.0 (see plan: clear-the-audit-backlog).",
   "main": "./dist/index.js",
@@ -257,7 +257,7 @@
   },
   "peerDependencies": {
     "docx": ">=8.0.0",
-    "jspdf": "^3.0.3 || ^4.2.1",
+    "jspdf": "^4.2.1",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },


### PR DESCRIPTION
## Summary

Completes the jspdf security fix from 5.1.0. That release widened the peer to `^3.0.3 || ^4.2.1`, but **every jspdf 3.x is vulnerable** (advisory `<=4.2.0` — no safe 3.x exists), so the union still let a consumer satisfy the peer with a vulnerable `3.0.4`. This tightens to `^4.2.1` so only patched versions satisfy the peer.

### Semver note

Narrowing a peer range is technically breaking, shipped as a **patch** because:
- jspdf is an **optional** peer (dynamic import; not installed unless you export PDFs)
- the removed versions are 100% vulnerable with no safe alternative
- the toolkit's jspdf API usage (`new jsPDF(...)`, text/vector primitives) is identical across 3↔4

Consumers on jspdf 4.2.1+ or not using PDF export: unaffected. Consumers pinned to jspdf 3.x: peer-range warning that correctly nudges them to the patched line.

### Docs

README + `exportPDF` JSDoc already specified jspdf ≥ 4.2.1 (from 5.1.0), so no doc changes were needed — verified as part of the pre-publish docs gate.

## Test plan

- [x] `pnpm jest --no-coverage` — 1249 pass
- [x] `pnpm verify:tarball` — 22 subpaths resolve (5.1.1 tgz)
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [ ] CI green