### PR TITLE
fix(examples): clear the four astro advisories in the SSR example

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,19 @@ updates:
         patterns:
           - "github/codeql-action*"
 
-  # npm ecosystem — root package.json + all workspace example apps.
+  # npm ecosystem — the root package.json and the pnpm workspace projects
+  # (packages/create-ndpr, packages/create-ndpr-unscoped, packages/ndpr-recipes)
+  # that resolve through the root lockfile.
+  #
+  # NOTE: examples/** is deliberately NOT covered. Those apps are outside the
+  # pnpm workspace (see pnpm-workspace.yaml#packages), have no lockfile, and are
+  # not reachable from directory "/" — so they receive no version-update PRs and
+  # never appear in `pnpm audit`. Dependabot *alerts* still scan them, which is
+  # the only reason the astro advisories in examples/ssr/astro surfaced at all.
+  # Adding "directories" entries for them would fix that, but all 14 example
+  # manifests pin @tantainnovative/ndpr-toolkit independently, so it needs a
+  # covering group first or it opens a PR per app.
+  #
   # Grouped to avoid PR storms; security updates always open their own PR.
   - package-ecosystem: "npm"
     directory: "/"

--- a/examples/ssr/astro/package.json
+++ b/examples/ssr/astro/package.json
@@ -9,12 +9,12 @@
     "preview": "astro preview"
   },
   "dependencies": {
-    "@astrojs/node": "^10.0.5",
-    "@astrojs/react": "^5.0.6",
+    "@astrojs/node": "^11.0.3",
+    "@astrojs/react": "^6.0.2",
     "@tantainnovative/ndpr-toolkit": "^5.1.1",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "astro": "^6.1.10",
+    "astro": "^7.1.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },


### PR DESCRIPTION
`examples/ssr/astro` was the sole source of open Dependabot alerts on this repo — all four of them.

| Advisory | Severity | Package | Floor |
|---|---|---|---|
| [GHSA-4g3v-8h47-v7g6](https://github.com/advisories/GHSA-4g3v-8h47-v7g6) — reflected XSS via unescaped View Transition animation properties | medium | `astro` | 7.1.0 |
| [GHSA-f48w-9m4c-m7f5](https://github.com/advisories/GHSA-f48w-9m4c-m7f5) — XSS via unescaped spread attribute names in `renderHTMLElement` (incomplete fix for CVE-2026-54298) | medium | `astro` | 7.0.6 |
| [GHSA-7pw4-f3q4-r2p2](https://github.com/advisories/GHSA-7pw4-f3q4-r2p2) — XSS via unescaped `transition:*` directive values on hydrated islands | low | `astro` | 7.0.4 |
| [GHSA-r557-wffq-wvrc](https://github.com/advisories/GHSA-r557-wffq-wvrc) — backslash-prefixed paths not recognized as internal by the trailing-slash redirect | low | `@astrojs/node` | 11.0.2 |

## Changes

- `astro` `^6.1.10` → `^7.1.6` — clears all three astro advisories (7.1.0 is the highest floor)
- `@astrojs/node` `^10.0.5` → `^11.0.3`
- `@astrojs/react` `^5.0.6` → `^6.0.2` — required because `@astrojs/node@11` peers on `astro ^7`

No source changes were needed. `output: "server"`, the standalone node adapter, and the React consent island all still work on astro 7.

## Verification

Building in place fails for an unrelated reason worth knowing about: Vite's upward config search finds the **monorepo root** `postcss.config.mjs`, whose `@tailwindcss/postcss` plugin isn't in the example's isolated `node_modules`. That's an artifact of the example living inside this checkout, not a defect — a standalone consumer has no parent config.

So this was verified the way a consumer actually gets it, by copying the example outside the repo tree:

```
├── @astrojs/node@11.0.3
├── @astrojs/react@6.0.2
└── astro@7.1.6

[build] output: "server"   [build] adapter: @astrojs/node
[build] Server built in 735ms   [build] Complete!

npm audit → found 0 vulnerabilities
```

## Why this rotted, and the gap left open

The `dependabot.yml` comment claimed the npm ecosystem covered "root package.json + all workspace example apps". **It does not.** `examples/**` is outside the pnpm workspace ([`pnpm-workspace.yaml#packages`](../blob/main/pnpm-workspace.yaml) lists only the three `packages/*` projects), has no lockfile, and is unreachable from `directory: "/"`. So those manifests receive no version-update PRs and never appear in `pnpm audit` — which is exactly how this example drifted onto a version carrying four known advisories. Dependabot *alerts* scan the whole repo regardless, which is the only reason they surfaced.

This PR corrects the comment to state that rather than hide it. It does **not** add coverage, because that is a judgement call worth making deliberately: all 14 example manifests pin `@tantainnovative/ndpr-toolkit` independently, so adding `directories: ["/examples/*", "/examples/ssr/*", "/examples/stackblitz/*"]` without a covering group first would open roughly a PR per app and immediately hit `open-pull-requests-limit: 10`.

Related, and also left alone here: all 14 examples still pin `@tantainnovative/ndpr-toolkit: ^5.1.1`, so they resolve to 5.7.4 and none of them demonstrates 6.0.0 — including `examples/nextjs-app`, which the README's StackBlitz and CodeSandbox buttons point at. There is no CI that builds any example, so bumping them is real work that needs its own verification pass.