### PR TITLE
fix(cli): close the TOCTOU race in ndpr audit --init

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -6,3 +6,12 @@ name: NDPR Toolkit CodeQL configuration
 # CodeQL analyzes instead of reporting impossible cross-branch assignments.
 paths-ignore:
   - packages/create-ndpr/templates/**
+  # Build output, not source. The workflow runs `pnpm build:lib` before
+  # initializing CodeQL so recipes and the docs site can resolve the package
+  # boundary, which leaves bundled and minified chunks in dist/ for the scan to
+  # find. Analyzing generated bundles only yields artifacts of the bundler —
+  # js/automatic-semicolon-insertion and js/whitespace-contradicts-precedence on
+  # tsup output — for code no human edits. dist/ is gitignored; the same code is
+  # already analyzed as source under packages/ndpr-toolkit/src.
+  - dist/**
+  - packages/*/dist/**

--- a/bin/ndpr.mjs
+++ b/bin/ndpr.mjs
@@ -86,8 +86,20 @@ async function main() {
 
   if (args.flags.init) {
     const out = resolve(process.cwd(), 'ndpr.audit.json');
-    if (existsSync(out)) { process.stderr.write(`Refusing to overwrite existing ${out}\n`); return 1; }
-    writeFileSync(out, JSON.stringify(STARTER_CONFIG, null, 2) + '\n');
+    // Write with 'wx' rather than checking existsSync first and writing
+    // second. That check-then-write pattern is a TOCTOU race: a file created
+    // in the window between the two calls is silently overwritten, which
+    // defeats the very guard below. 'wx' makes the refusal atomic — the open
+    // fails with EEXIST and nothing is written.
+    try {
+      writeFileSync(out, JSON.stringify(STARTER_CONFIG, null, 2) + '\n', { flag: 'wx' });
+    } catch (err) {
+      if (err?.code === 'EEXIST') {
+        process.stderr.write(`Refusing to overwrite existing ${out}\n`);
+        return 1;
+      }
+      throw err;
+    }
     process.stdout.write(`Wrote starter config to ${out}\n`);
     return 0;
   }


### PR DESCRIPTION
Fixes CodeQL alert [246](https://github.com/mr-tanta/ndpr-toolkit/security/code-scanning/246) — `js/file-system-race`, **high**, `bin/ndpr.mjs:90`. Confirmed live: its most recent instance is on `d1b858b1`, current `main`.

## The bug

```js
if (existsSync(out)) { process.stderr.write(`Refusing to overwrite existing ${out}\n`); return 1; }
writeFileSync(out, JSON.stringify(STARTER_CONFIG, null, 2) + '\n');
```

The check and the write are separate operations. A file created in the window between them is silently overwritten — which defeats the exact guard the check exists to provide. Low practical impact (a local CLI writing into the user's own cwd), but `bin/ndpr.mjs` ships in the published package's `files` array, and the fix is contained.

## The fix

Write with `{ flag: 'wx' }`, so the refusal is atomic — the open itself fails with `EEXIST` and nothing is written. Observable behavior is unchanged: same stderr message, same exit 1 on an existing file, same exit 0 and stdout line on a fresh write.

`d3400e44` ("make scaffold writes race-safe") addressed this class of bug in the create-ndpr scaffolder; the published `ndpr` binary was not covered by that pass.

## Verification

Against a temp directory:

| Case | Result |
|---|---|
| Fresh `--init` | writes 1369 bytes, exit 0 |
| Second `--init` | `Refusing to overwrite existing …`, exit 1 |
| Sentinel file at target path | survives untouched, exit 1 |

Plus a full local `pnpm verify:ci`: 116 suites / 1468 tests, lint, `build:lib`, `typecheck:recipes`, `tsc --noEmit`, 15 create-ndpr scaffold combinations, Storybook typecheck and build, and the 22-subpath tarball probe.

## Also: stop scanning build output

Four of the remaining open CodeQL alerts are in `dist/chunk-*.js` / `dist/chunk-*.mjs`. The CodeQL workflow runs `pnpm build:lib` before `codeql-action/init` (so recipes and the docs site can resolve the package boundary), which leaves bundled tsup output in `dist/` for the scan to find. The findings there — `js/automatic-semicolon-insertion`, `js/whitespace-contradicts-precedence` — are artifacts of bundling, on generated code nobody edits. `dist/` is gitignored, and the same logic is already analyzed as source under `packages/ndpr-toolkit/src`.

Added `dist/**` and `packages/*/dist/**` to `paths-ignore`, which should retire those four.

The rest of the open alerts are `note`-level `js/unused-local-variable` in tests and docs-site pages, plus two `warning`-level ones (`js/react/unused-or-undefined-state-property` in `ErrorBoundary.tsx`, `js/useless-assignment-to-local` in `PolicyGenerator.tsx`). None are security-relevant and none are touched here.