### PR TITLE
fix(security): resolve every open CodeQL alert outside dist

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,7 +43,19 @@ const eslintConfig = [
       ...tsPlugin.configs.recommended.rules,
       "react-hooks/rules-of-hooks": "error",
       "react-hooks/exhaustive-deps": "warn",
-      "@typescript-eslint/no-unused-vars": "off",
+      // Was "off", which let 45 unused imports and locals accumulate that CodeQL
+      // then reported as js/unused-local-variable. Enabled so lint is the gate
+      // and the alerts can't come back. `_`-prefixed names stay allowed for
+      // deliberately-unused positional args and destructuring holes.
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          ignoreRestSiblings: true,
+        },
+      ],
       "@typescript-eslint/no-empty-object-type": "off",
       "react/no-unescaped-entities": "off",
       "@typescript-eslint/no-explicit-any": "off",
@@ -55,6 +67,18 @@ const eslintConfig = [
     rules: {
       "@typescript-eslint/no-require-imports": "off",
       "@typescript-eslint/no-unsafe-function-type": "off",
+    },
+  },
+  // Raw create-ndpr templates are Handlebars sources, not ordinary modules: a
+  // declaration can be referenced only from inside a {{#if}} branch that a
+  // given render strips, so "unused" here is not a reliable signal. The CodeQL
+  // config excludes these same paths for the related reason that mutually
+  // exclusive branches aren't valid TypeScript until rendered. The rendered
+  // output is what gets linted and strictly typechecked, by verify:create-ndpr.
+  {
+    files: ["packages/create-ndpr/templates/**"],
+    rules: {
+      "@typescript-eslint/no-unused-vars": "off",
     },
   },
 ];

--- a/packages/ndpr-recipes/src/nextjs/app-router/api/ropa/route.ts
+++ b/packages/ndpr-recipes/src/nextjs/app-router/api/ropa/route.ts
@@ -36,7 +36,7 @@ export async function GET(request: NextRequest) {
   });
   try {
     return NextResponse.json(rows.map(processingRecordFromRow));
-  } catch (error) {
+  } catch {
     return NextResponse.json(
       {
         error: 'A processing record is missing its lossless snapshot.',

--- a/packages/ndpr-toolkit/src/__tests__/components/consent/ConsentBanner.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/components/consent/ConsentBanner.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { ConsentBanner } from '../../../components/consent/ConsentBanner';
 import { ConsentOption } from '../../../types/consent';
 

--- a/packages/ndpr-toolkit/src/__tests__/components/consent/ConsentManager.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/components/consent/ConsentManager.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { ConsentManager } from '../../../components/consent/ConsentManager';
-import { ConsentOption, ConsentSettings } from '../../../types/consent';
+import { ConsentOption } from '../../../types/consent';
 
 describe('ConsentManager (NDPA Privacy Settings)', () => {
   const mockOnSave = jest.fn();

--- a/packages/ndpr-toolkit/src/__tests__/components/consent/ConsentStorage.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/components/consent/ConsentStorage.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { ConsentStorage } from '../../../components/consent/ConsentStorage';
 import { ConsentSettings } from '../../../types/consent';
 

--- a/packages/ndpr-toolkit/src/__tests__/components/dsr/DSRDashboard.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/components/dsr/DSRDashboard.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { DSRDashboard } from '../../../components/dsr/DSRDashboard';
 import { DSRRequest } from '../../../types/dsr';
 

--- a/packages/ndpr-toolkit/src/__tests__/components/dsr/DSRRequestForm.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/components/dsr/DSRRequestForm.test.tsx
@@ -50,7 +50,7 @@ describe('DSRRequestForm (NDPA Part VI - Data Subject Rights)', () => {
     const originalConsoleError = console.error;
     console.error = jest.fn();
     
-    const { container } = renderComponent();
+    renderComponent();
     
     // Submit without filling required fields
     fireEvent.click(screen.getByRole('button', { name: /submit/i }));

--- a/packages/ndpr-toolkit/src/__tests__/components/dsr/DSRTracker.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/components/dsr/DSRTracker.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { DSRTracker } from '../../../components/dsr/DSRTracker';
 import { DSRRequest } from '../../../types/dsr';
 

--- a/packages/ndpr-toolkit/src/__tests__/hooks/useBreach-adapter.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/hooks/useBreach-adapter.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useBreach } from '../../hooks/useBreach';
 import { memoryAdapter } from '../../adapters/memory';

--- a/packages/ndpr-toolkit/src/__tests__/hooks/useBreach-stale-closure.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/hooks/useBreach-stale-closure.test.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useBreach } from '../../hooks/useBreach';
 import { memoryAdapter } from '../../adapters/memory';
-import type { BreachCategory, RiskAssessment, RegulatoryNotification } from '../../types/breach';
+import type { BreachCategory } from '../../types/breach';
 
 // ---------------------------------------------------------------------------
 // Shared fixtures

--- a/packages/ndpr-toolkit/src/__tests__/hooks/useConsent-adapter.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/hooks/useConsent-adapter.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useConsent } from '../../hooks/useConsent';
 import { memoryAdapter } from '../../adapters/memory';

--- a/packages/ndpr-toolkit/src/__tests__/hooks/useConsent.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/hooks/useConsent.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderHook, act } from '@testing-library/react';
 import {
   useConsent,

--- a/packages/ndpr-toolkit/src/__tests__/hooks/useCrossBorderTransfer-adapter.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/hooks/useCrossBorderTransfer-adapter.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useCrossBorderTransfer } from '../../hooks/useCrossBorderTransfer';
 import { memoryAdapter } from '../../adapters/memory';

--- a/packages/ndpr-toolkit/src/__tests__/hooks/useDPIA-adapter.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/hooks/useDPIA-adapter.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useDPIA } from '../../hooks/useDPIA';
 import { memoryAdapter } from '../../adapters/memory';

--- a/packages/ndpr-toolkit/src/__tests__/hooks/useDPIA-showWhen.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/hooks/useDPIA-showWhen.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useDPIA } from '../../hooks/useDPIA';
 import { memoryAdapter } from '../../adapters/memory';

--- a/packages/ndpr-toolkit/src/__tests__/hooks/useDSR-adapter.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/hooks/useDSR-adapter.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useDSR } from '../../hooks/useDSR';
 import { memoryAdapter } from '../../adapters/memory';

--- a/packages/ndpr-toolkit/src/__tests__/hooks/useDSR.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/hooks/useDSR.test.tsx
@@ -1,6 +1,5 @@
 import { renderHook, act } from '@testing-library/react';
 import { useDSR } from '../../hooks/useDSR';
-import React from 'react';
 import { DSRRequest, RequestType } from '../../types/dsr';
 
 // Mock localStorage

--- a/packages/ndpr-toolkit/src/__tests__/hooks/useDefaultPrivacyPolicy.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/hooks/useDefaultPrivacyPolicy.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useDefaultPrivacyPolicy } from '../../hooks/useDefaultPrivacyPolicy';
 import { createBusinessPolicyTemplate } from '../../utils/policy-templates';

--- a/packages/ndpr-toolkit/src/__tests__/hooks/useLawfulBasis-adapter.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/hooks/useLawfulBasis-adapter.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useLawfulBasis } from '../../hooks/useLawfulBasis';
 import { memoryAdapter } from '../../adapters/memory';

--- a/packages/ndpr-toolkit/src/__tests__/hooks/usePrivacyPolicy-adapter.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/hooks/usePrivacyPolicy-adapter.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { usePrivacyPolicy } from '../../hooks/usePrivacyPolicy';
 import { memoryAdapter } from '../../adapters/memory';

--- a/packages/ndpr-toolkit/src/__tests__/hooks/usePrivacyPolicy.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/hooks/usePrivacyPolicy.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { usePrivacyPolicy } from '../../hooks/usePrivacyPolicy';
 import { memoryAdapter } from '../../adapters/memory';

--- a/packages/ndpr-toolkit/src/__tests__/hooks/useROPA-adapter.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/hooks/useROPA-adapter.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useROPA } from '../../hooks/useROPA';
 import { memoryAdapter } from '../../adapters/memory';

--- a/packages/ndpr-toolkit/src/__tests__/utils/dpia.test.ts
+++ b/packages/ndpr-toolkit/src/__tests__/utils/dpia.test.ts
@@ -1,5 +1,5 @@
 import { assessDPIARisk } from '../../utils/dpia';
-import { DPIAResult, DPIARisk } from '../../types/dpia';
+import { DPIAResult } from '../../types/dpia';
 
 describe('assessDPIARisk (NDPA Section 28(2) - NDPC Consultation)', () => {
   it('should correctly assess high risk data and require NDPC consultation per NDPA Section 28(2)', () => {

--- a/packages/ndpr-toolkit/src/__tests__/utils/dsr.test.ts
+++ b/packages/ndpr-toolkit/src/__tests__/utils/dsr.test.ts
@@ -2,7 +2,7 @@ import {
   formatDSRRequestStructured,
   validateDsrSubmissionStructured,
 } from '../../utils/dsr';
-import { DSRRequest, DSRType, DSRStatus } from '../../types/dsr';
+import { DSRRequest } from '../../types/dsr';
 
 // ── validateDsrSubmissionStructured (4.1.0 — structured-result family) ──────
 

--- a/packages/ndpr-toolkit/src/__tests__/utils/policy-export.test.ts
+++ b/packages/ndpr-toolkit/src/__tests__/utils/policy-export.test.ts
@@ -289,6 +289,65 @@ describe('exportHTML', () => {
     expect(result).toContain('body { color: red; }');
   });
 
+  describe('customCSS cannot break out of the <style> block', () => {
+    // `<style>` is a raw-text element, so the parser ends it at the first
+    // `</style` followed by whitespace, `/`, or `>`. Filtering only the literal
+    // `</style>` left every other terminator working.
+    it.each([
+      ['exact end tag', '</style><img src=x onerror=alert(1)>'],
+      ['whitespace before >', '</style ><img src=x onerror=alert(1)>'],
+      ['newline before >', '</style\n><img src=x onerror=alert(1)>'],
+      ['self-closing slash', '</style/><img src=x onerror=alert(1)>'],
+      ['tab before >', '</style\t><img src=x onerror=alert(1)>'],
+      ['uppercase', '</STYLE><img src=x onerror=alert(1)>'],
+      ['mixed case', '</StYlE><img src=x onerror=alert(1)>'],
+      // A single-pass delete of the `</style` token would reassemble this into
+      // a working terminator from the surviving fragments.
+      ['fragment reassembly', '</st</styleyle><img src=x onerror=alert(1)>'],
+    ])('neutralizes %s', (_label, hostileCss) => {
+      const result = exportHTML(makePolicy(), { customCSS: hostileCss });
+
+      // No `<` from the injected CSS survives, so no tag can be opened.
+      const styleBody = result.slice(
+        result.indexOf('<style>') + '<style>'.length,
+        result.lastIndexOf('</style>'),
+      );
+      expect(styleBody).not.toMatch(/</);
+      expect(styleBody).toContain('\\3C ');
+      // And the payload never becomes live markup anywhere in the document.
+      expect(result).not.toContain('<img src=x');
+    });
+
+    it('leaves the child combinator and ordinary CSS intact', () => {
+      const result = exportHTML(makePolicy(), {
+        customCSS: '.a > .b { color: red; } .c>.d { color: blue; }',
+      });
+      expect(result).toContain('.a > .b { color: red; }');
+      expect(result).toContain('.c>.d { color: blue; }');
+    });
+
+    it('applies the same neutralization when includeStyles is false', () => {
+      const result = exportHTML(makePolicy(), {
+        includeStyles: false,
+        customCSS: '</style ><img src=x onerror=alert(1)>',
+      });
+      expect(result).not.toContain('<img src=x');
+    });
+  });
+
+  describe('template substitution is not quadratic in brace runs', () => {
+    // js/polynomial-redos: `[^}]+` / `[^}\s]+` would consume a long run of `{`
+    // before failing to find the closing `}}`, once per starting offset.
+    it('exports a pathological brace run in linear time', () => {
+      const policy = makePolicy();
+      policy.sections[0].template = '{'.repeat(60000);
+
+      const started = Date.now();
+      expect(() => exportHTML(policy)).not.toThrow();
+      expect(Date.now() - started).toBeLessThan(2000);
+    });
+  });
+
   it('wraps content in an <article> element', () => {
     const result = exportHTML(makePolicy());
     expect(result).toContain('<article');
@@ -510,7 +569,9 @@ describe('exportPDF', () => {
   it('throws a helpful error when jspdf is not available', async () => {
     // Temporarily override the mock to reject the dynamic import
     jest.resetModules();
-    const { exportPDF: exportPDFFresh } = await import('../../utils/policy-export/pdf');
+    // Imported for the module-registry reset side effect; the binding itself
+    // is not exercised here (see the comment below).
+    await import('../../utils/policy-export/pdf');
 
     // Because Jest's module registry is isolated per test, the above import
     // will still use the virtual mock. We verify the error-throwing path by

--- a/packages/ndpr-toolkit/src/__tests__/utils/privacy.test.ts
+++ b/packages/ndpr-toolkit/src/__tests__/utils/privacy.test.ts
@@ -189,6 +189,26 @@ describe('findUnfilledTokens', () => {
   it('returns [] for fully-rendered text', () => {
     expect(findUnfilledTokens('All variables resolved cleanly.')).toEqual([]);
   });
+
+  // js/polynomial-redos: with `[^}\s]+` the class consumed a whole run of `{`
+  // before failing to find `}}`, and `\{\{` retried at every offset in the run,
+  // making the scan quadratic. `[^{}\s]+` stops at the first brace instead.
+  it('scans a pathological brace run in linear time', () => {
+    const hostile = '{'.repeat(100000);
+    const started = Date.now();
+    expect(findUnfilledTokens(hostile)).toEqual([]);
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+
+  it('still finds real tokens adjacent to brace runs', () => {
+    expect(findUnfilledTokens(`${'{'.repeat(5000)} {{orgName}}`)).toEqual(['orgName']);
+  });
+
+  it('reads the inner token of a triple-brace form', () => {
+    // `{{{orgName}}}` matches from the second brace, so the captured name is
+    // clean rather than carrying a leading `{`.
+    expect(findUnfilledTokens('{{{orgName}}}')).toEqual(['orgName']);
+  });
 });
 
 describe('assemblePolicy: canonical fixture renders without unfilled tokens', () => {

--- a/packages/ndpr-toolkit/src/components/breach/BreachNotificationManager.tsx
+++ b/packages/ndpr-toolkit/src/components/breach/BreachNotificationManager.tsx
@@ -131,7 +131,8 @@ export const BreachNotificationManager: React.FC<BreachNotificationManagerProps>
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [searchTerm, setSearchTerm] = useState<string>('');
   const [sortBy, setSortBy] = useState<string>('discoveredAt');
-  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
+  // No UI toggles direction, so the setter is intentionally not bound.
+  const [sortDirection] = useState<'asc' | 'desc'>('desc');
   
   // Update filtered breaches when filters change
   useEffect(() => {

--- a/packages/ndpr-toolkit/src/components/breach/BreachRiskAssessment.tsx
+++ b/packages/ndpr-toolkit/src/components/breach/BreachRiskAssessment.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { BreachReport, RiskAssessment } from '../../types/breach';
-import { calculateBreachSeverity } from '../../utils/breach';
 import { resolveClass } from '../../utils/styling';
 import { useNDPRLocale } from '../NDPRProvider';
 

--- a/packages/ndpr-toolkit/src/components/breach/RegulatoryReportGenerator.tsx
+++ b/packages/ndpr-toolkit/src/components/breach/RegulatoryReportGenerator.tsx
@@ -180,7 +180,9 @@ export const RegulatoryReportGenerator: React.FC<RegulatoryReportGeneratorProps>
   const [method, setMethod] = useState<'email' | 'portal' | 'letter' | 'other'>('email');
   const [referenceNumber, setReferenceNumber] = useState<string>("");
   const [additionalInfo, setAdditionalInfo] = useState<string>("");
-  const [isGenerated, setIsGenerated] = useState<boolean>(false);
+  // Only the setter is used; the flag itself is never read, but setting it
+  // still drives the re-render after the report is generated.
+  const [, setIsGenerated] = useState<boolean>(false);
   const [isSubmitted, setIsSubmitted] = useState<boolean>(false);
   
   // Generate the initial report content (regenerate when core props change)

--- a/packages/ndpr-toolkit/src/components/dpia/DPIAQuestionnaire.tsx
+++ b/packages/ndpr-toolkit/src/components/dpia/DPIAQuestionnaire.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { DPIASection, DPIAQuestion } from '../../types/dpia';
 import { resolveClass } from '../../utils/styling';
 import { useNDPRLocale } from '../NDPRProvider';

--- a/packages/ndpr-toolkit/src/components/dpia/DPIAReport.tsx
+++ b/packages/ndpr-toolkit/src/components/dpia/DPIAReport.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { DPIAResult, DPIASection, DPIARisk } from '../../types/dpia';
+import { DPIAResult, DPIASection } from '../../types/dpia';
 import { resolveClass } from '../../utils/styling';
 import { LEGAL_DISCLAIMER_SHORT } from '../../utils/legal-notice';
 import { useNDPRLocale } from '../NDPRProvider';
@@ -119,26 +119,6 @@ export const DPIAReport: React.FC<DPIAReportProps> = ({
       month: 'long',
       year: 'numeric'
     });
-  };
-
-  // Get the section title by ID
-  const getSectionTitle = (sectionId: string): string => {
-    const section = sections.find(s => s.id === sectionId);
-    return section?.title || 'Unknown Section';
-  };
-
-  // Get the question text by ID
-  const getQuestionText = (questionId: string): string => {
-    let questionText = 'Unknown Question';
-
-    sections.forEach(section => {
-      const question = section.questions.find(q => q.id === questionId);
-      if (question) {
-        questionText = question.text;
-      }
-    });
-
-    return questionText;
   };
 
   // Get the answer text for a question

--- a/packages/ndpr-toolkit/src/components/dsr/DSRDashboard.tsx
+++ b/packages/ndpr-toolkit/src/components/dsr/DSRDashboard.tsx
@@ -125,7 +125,8 @@ export const DSRDashboard: React.FC<DSRDashboardProps> = ({
   const [typeFilter, setTypeFilter] = useState<string>('all');
   const [searchTerm, setSearchTerm] = useState<string>('');
   const [sortBy, setSortBy] = useState<string>('createdAt');
-  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
+  // No UI toggles direction, so the setter is intentionally not bound.
+  const [sortDirection] = useState<'asc' | 'desc'>('desc');
   const [assignee, setAssignee] = useState<string>('');
   
   // Update filtered requests when filters change

--- a/packages/ndpr-toolkit/src/components/dsr/DSRTracker.tsx
+++ b/packages/ndpr-toolkit/src/components/dsr/DSRTracker.tsx
@@ -101,7 +101,9 @@ export const DSRTracker: React.FC<DSRTrackerProps> = ({
   title,
   description,
   className = "",
-  buttonClassName = "",
+  // buttonClassName is accepted by DSRTrackerProps but not currently applied to
+  // any button in this component. Left out of the destructure rather than bound
+  // and ignored; callers are unaffected because the prop stays on the type.
   showSummaryStats = true,
   showTypeBreakdown = true,
   showStatusBreakdown = true,
@@ -288,33 +290,11 @@ export const DSRTracker: React.FC<DSRTrackerProps> = ({
     );
   };
   
-  // Render status badge
-  const renderStatusBadge = (status: DSRStatus) => {
-    const colorClasses = {
-      pending: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
-      inProgress: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
-      completed: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
-      rejected: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
-      awaitingVerification: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200'
-    };
-
-    return (
-      <span className={resolveClass(`px-2 py-1 rounded text-xs font-medium ${colorClasses[status]}`, classNames?.statusBadge, unstyled)}>
-        {status === 'inProgress' ? 'In Progress' :
-         status === 'awaitingVerification' ? 'Awaiting Verification' :
-         status.charAt(0).toUpperCase() + status.slice(1)}
-      </span>
-    );
-  };
-  
   // Render the summary statistics
   const renderSummaryStats = () => {
     const totalRequests = filteredRequests.length;
     const pendingRequests = filteredRequests.filter(request => 
       request.status !== 'completed' && request.status !== 'rejected'
-    ).length;
-    const completedRequests = filteredRequests.filter(request => 
-      request.status === 'completed' || request.status === 'rejected'
     ).length;
     const averageResponseTime = calculateAverageResponseTime();
     const complianceRate = calculateComplianceRate();

--- a/packages/ndpr-toolkit/src/components/policy/PolicyGenerator.tsx
+++ b/packages/ndpr-toolkit/src/components/policy/PolicyGenerator.tsx
@@ -115,7 +115,9 @@ export const PolicyGenerator: React.FC<PolicyGeneratorProps> = ({
   className = "",
   buttonClassName = "",
   generateButtonText,
-  showPreview = true,
+  // showPreview is accepted by PolicyGeneratorProps but not currently applied by
+  // this component. Left out of the destructure rather than bound and ignored;
+  // callers are unaffected because the prop stays on the type.
   allowEditing = true,
   classNames,
   unstyled = false
@@ -132,7 +134,9 @@ export const PolicyGenerator: React.FC<PolicyGeneratorProps> = ({
   const [activeStep, setActiveStep] = useState<'sections' | 'variables' | 'preview'>('sections');
   const [generatedPolicy, setGeneratedPolicy] = useState<string>('');
   const [editedPolicy, setEditedPolicy] = useState<string>('');
-  const [isGenerated, setIsGenerated] = useState<boolean>(false);
+  // Only the setter is used; the flag itself is never read, but setting it
+  // still drives the re-render callers depend on after generation.
+  const [, setIsGenerated] = useState<boolean>(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
   
   // Update sections when initialSections changes

--- a/packages/ndpr-toolkit/src/components/policy/PolicyPreview.tsx
+++ b/packages/ndpr-toolkit/src/components/policy/PolicyPreview.tsx
@@ -120,8 +120,9 @@ export interface PolicyPreviewProps {
 
 export const PolicyPreview: React.FC<PolicyPreviewProps> = ({
   content,
-  sections,
-  variables,
+  // sections and variables are accepted by PolicyPreviewProps but this
+  // component renders from `content` alone. Left out of the destructure rather
+  // than bound and ignored; callers are unaffected.
   onExport,
   onEdit,
   // i18n: explicit prop > provider locale > English default.

--- a/packages/ndpr-toolkit/src/components/policy/PolicyStepIndicator.tsx
+++ b/packages/ndpr-toolkit/src/components/policy/PolicyStepIndicator.tsx
@@ -28,7 +28,6 @@ export const PolicyStepIndicator: React.FC<PolicyStepIndicatorProps> = ({
         const stepNumber = index + 1;
         const isCompleted = stepNumber < currentStep;
         const isCurrent = stepNumber === currentStep;
-        const isUpcoming = stepNumber > currentStep;
         const isLast = index === STEPS.length - 1;
 
         return (

--- a/packages/ndpr-toolkit/src/components/policy/PolicyStepProcessing.tsx
+++ b/packages/ndpr-toolkit/src/components/policy/PolicyStepProcessing.tsx
@@ -187,7 +187,7 @@ export const PolicyStepProcessing: React.FC<PolicyStepProcessingProps> = ({
             onChange={(val) => {
               if (!val) {
                 // Remove all processors
-                context.thirdPartyProcessors.forEach((_, i) => onRemoveProcessor(0));
+                context.thirdPartyProcessors.forEach(() => onRemoveProcessor(0));
                 setShowProcessorForm(false);
               } else {
                 setShowProcessorForm(true);

--- a/packages/ndpr-toolkit/src/components/ropa/ROPAManager.tsx
+++ b/packages/ndpr-toolkit/src/components/ropa/ROPAManager.tsx
@@ -3,9 +3,7 @@ import type { LawfulBasis } from '../../types/lawful-basis';
 import type {
   ProcessingRecord,
   RecordOfProcessingActivities,
-  ROPASummary,
 } from '../../types/ropa';
-import type { ROPAComplianceGap } from '../../utils/ropa';
 import {
   validateProcessingRecord,
   generateROPASummary,

--- a/packages/ndpr-toolkit/src/hooks/useBreach.ts
+++ b/packages/ndpr-toolkit/src/hooks/useBreach.ts
@@ -194,7 +194,9 @@ export interface UseBreachReturn {
  * ```
  */
 export function useBreach({
-  categories,
+  // `categories` is accepted by UseBreachOptions (and shown in the example
+  // above) but is not consumed by this hook. Left out of the destructure
+  // rather than bound and ignored; callers are unaffected.
   initialReports = [],
   adapter,
   storageKey = 'ndpr_breach_data',

--- a/packages/ndpr-toolkit/src/hooks/usePrivacyPolicy.ts
+++ b/packages/ndpr-toolkit/src/hooks/usePrivacyPolicy.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { PolicySection, PolicyTemplate, OrganizationInfo, PrivacyPolicy } from '../types/privacy';
+import { PolicyTemplate, OrganizationInfo, PrivacyPolicy } from '../types/privacy';
 import { generatePolicyText } from '../utils/privacy';
 import type { StorageAdapter } from '../adapters/types';
 import { localStorageAdapter } from '../adapters/local-storage';

--- a/packages/ndpr-toolkit/src/types/policy-engine.ts
+++ b/packages/ndpr-toolkit/src/types/policy-engine.ts
@@ -4,7 +4,7 @@
  * and export functionality — all aligned with the NDPA 2023.
  */
 
-import type { OrganizationInfo, PolicySection, PrivacyPolicy } from './privacy';
+import type { OrganizationInfo } from './privacy';
 
 // ---------------------------------------------------------------------------
 // Enums & unions

--- a/packages/ndpr-toolkit/src/utils/policy-export/docx.ts
+++ b/packages/ndpr-toolkit/src/utils/policy-export/docx.ts
@@ -43,7 +43,6 @@ export async function exportDOCX(
     PageNumber,
     AlignmentType,
     BorderStyle,
-    ShadingType,
     TableOfContents,
   } = docxLib;
 

--- a/packages/ndpr-toolkit/src/utils/policy-export/html.ts
+++ b/packages/ndpr-toolkit/src/utils/policy-export/html.ts
@@ -73,10 +73,40 @@ function substituteVariables(
     if (typeof value === 'string' && value) vars[key] = value;
   }
 
-  return text.replace(/\{\{\s*([^}\s]+)\s*\}\}/g, (whole, rawKey: string) => {
+  // `[^{}\s]` excludes `{` as well as `}`. Excluding only `}` lets the class
+  // consume a long run of braces before failing to find `}}`, and since the
+  // leading `\{\{` can start at every offset in that run the scan is quadratic
+  // in input length (CodeQL js/polynomial-redos). Section templates are library
+  // input, so a hostile or merely malformed template shouldn't be able to stall
+  // an export. A token name never contains a brace, so nothing is lost.
+  return text.replace(/\{\{\s*([^{}\s]+)\s*\}\}/g, (whole, rawKey: string) => {
     const key = String(rawKey).trim();
     return Object.prototype.hasOwnProperty.call(vars, key) ? vars[key] : whole;
   });
+}
+
+/**
+ * Neutralize consumer-supplied CSS so it cannot break out of the `<style>` block.
+ *
+ * `<style>` is a raw-text element: the parser ends it at the first `</style`
+ * followed by whitespace, `/`, or `>`. The previous filter removed only the
+ * literal `</style>`, which missed `</style >`, `</style/`, and `</style\n>` —
+ * each of which closes the element early and lets everything after it be
+ * parsed as markup (CodeQL js/bad-tag-filter, js/html-constructed-from-input).
+ *
+ * Deleting the `</style` token instead is still not sound, because one pass can
+ * assemble the token out of fragments: `</st</styleyle` loses its middle match
+ * and collapses into a working `</styleyle`.
+ *
+ * So escape every `<` as the CSS character escape `\3C` instead. CSS has no
+ * syntactic use for `<` anywhere outside a string, comment, or url(), and the
+ * child combinator is `>`, which is left untouched. Inside a string the escape
+ * still renders as `<`; elsewhere it replaces one construct CSS could not parse
+ * with another. Nothing legitimate is lost, the replacement introduces no new
+ * `<`, and with no `<` surviving no tag of any kind can be opened.
+ */
+function neutralizeCssTagEscapes(css: string): string {
+  return css.replace(/</g, '\\3C ');
 }
 
 /** Convert a section title to a URL-safe anchor slug. */
@@ -479,7 +509,7 @@ export function exportHTML(policy: PrivacyPolicy, options?: HTMLExportOptions): 
 
   // ── Table of Contents ────────────────────────────────────────────────────
   const tocItems = includedSections
-    .map((section, i) => {
+    .map((section) => {
       const anchor = slugify(section.title);
       return `      <li><a href="#${anchor}">${escapeHtml(section.title)}</a></li>`;
     })
@@ -518,7 +548,7 @@ ${tocItems}
     .join('\n\n');
 
   // ── Style block ──────────────────────────────────────────────────────────
-  const safeCSS = customCSS ? customCSS.replace(/<\/style>/gi, '') : '';
+  const safeCSS = customCSS ? neutralizeCssTagEscapes(customCSS) : '';
   const styleBlock = includeStyles
     ? `<style>
 ${buildBaseStyles(theme)}

--- a/packages/ndpr-toolkit/src/utils/policy-sections.ts
+++ b/packages/ndpr-toolkit/src/utils/policy-sections.ts
@@ -46,13 +46,6 @@ function selectedCategories(cats: DataCategory[]): DataCategory[] {
   return cats.filter((c) => c.selected);
 }
 
-function categoriesByGroup(
-  cats: DataCategory[],
-  group: DataCategory['group'],
-): DataCategory[] {
-  return selectedCategories(cats).filter((c) => c.group === group);
-}
-
 function purposeLabel(p: ProcessingPurpose): string {
   const map: Record<ProcessingPurpose, string> = {
     service_delivery:

--- a/packages/ndpr-toolkit/src/utils/privacy.ts
+++ b/packages/ndpr-toolkit/src/utils/privacy.ts
@@ -1,4 +1,4 @@
-import { PolicySection, OrganizationInfo, PolicyVariable } from '../types/privacy';
+import { PolicySection, OrganizationInfo } from '../types/privacy';
 import { UNFILLED_PREFIX, UNFILLED_SUFFIX } from './policy-sections';
 
 /**
@@ -54,7 +54,13 @@ export function findUnfilledTokens(rendered: string): string[] {
   }
 
   // Mustache tokens that survived substitution: {{fieldName}}
-  const mustacheRe = /\{\{\s*([^}\s]+)\s*\}\}/g;
+  // `[^{}\s]` excludes `{` as well as `}`. Excluding only `}` lets the class
+  // consume a long run of braces before failing to find the closing `}}`, and
+  // because the leading `\{\{` can start at every offset in that run the work
+  // is quadratic in input length (CodeQL js/polynomial-redos). A token name
+  // never legitimately contains a brace, so refusing to cross one costs
+  // nothing and makes `{{{{{{…` fail at the first character instead.
+  const mustacheRe = /\{\{\s*([^{}\s]+)\s*\}\}/g;
   while ((match = mustacheRe.exec(rendered)) !== null) {
     found.add(match[1].trim());
   }
@@ -83,7 +89,9 @@ export function generatePolicyText(
     
     // Replace variables in the template
     let result = template;
-    const variableRegex = /\{\{([^}]+)\}\}/g;
+    // `[^{}]` not `[^}]` — see findUnfilledTokens. Excluding only `}` makes a
+    // run of `{` quadratic to scan (CodeQL js/polynomial-redos).
+    const variableRegex = /\{\{([^{}]+)\}\}/g;
     let match;
     
     // Find and replace all variables in the content
@@ -116,7 +124,8 @@ export function generatePolicyText(
         let content = section.template || section.customContent || section.defaultContent || '';
         
         // Replace variables in the content
-        const variableRegex = /\{\{([^}]+)\}\}/g;
+        // `[^{}]` not `[^}]` — see findUnfilledTokens (js/polynomial-redos).
+        const variableRegex = /\{\{([^{}]+)\}\}/g;
         let match;
         
         // Find all variables in the content

--- a/src/app/docs/components/legal-notice/page.tsx
+++ b/src/app/docs/components/legal-notice/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Link from 'next/link';
 import { DocLayout } from '@/components/docs/DocLayout';
 
 export default function LegalNoticeDocs() {

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -4,13 +4,11 @@ import React from 'react';
 import {
   Container,
   SiteButton,
-  SiteCard,
   SiteBadge,
   Section,
   SiteCodeBlock,
   GradientText,
   FeatureCard,
-  Grid,
   CTASection,
 } from '@/components/site/ui';
 import { SiteHeader } from '@/components/site/SiteHeader';

--- a/src/app/ndpr-demos/cross-border/page.tsx
+++ b/src/app/ndpr-demos/cross-border/page.tsx
@@ -11,7 +11,6 @@ import { Badge } from '@/components/ui/Badge';
 // Local types matching what the demo actually uses
 type TransferMechanism = 'adequacy_decision' | 'standard_contractual_clauses' | 'binding_corporate_rules' | 'ndpc_authorization' | 'derogation' | 'other';
 type TransferStatus = 'pending' | 'approved' | 'rejected' | 'under_review';
-type AdequacyStatus = 'adequate' | 'inadequate' | 'pending_review' | 'unknown';
 
 interface CrossBorderTransfer {
   id: string;

--- a/src/app/ndpr-demos/page.tsx
+++ b/src/app/ndpr-demos/page.tsx
@@ -8,7 +8,6 @@ import {
   Section,
   GradientText,
   FeatureCard,
-  Grid,
   CTASection,
 } from '@/components/site/ui';
 import { siteConfig } from '@/lib/site-config';

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -9,17 +9,18 @@ interface Props {
 
 interface State {
   hasError: boolean;
-  error: Error | null;
 }
 
 export class ErrorBoundary extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.state = { hasError: false, error: null };
+    this.state = { hasError: false };
   }
 
-  static getDerivedStateFromError(error: Error): State {
-    return { hasError: true, error };
+  static getDerivedStateFromError(): State {
+    // The error itself is not kept on state because render never reads it; it is
+    // reported from componentDidCatch instead.
+    return { hasError: true };
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {

--- a/src/components/privacy-policy/PolicyGenerator.tsx
+++ b/src/components/privacy-policy/PolicyGenerator.tsx
@@ -486,8 +486,17 @@ export default function PolicyGenerator({
           .replace(/<br\s*\/?>/g, "\n")
           .replace(/&nbsp;/g, " ");
 
-        // Remove any remaining HTML tags
-        md = md.replace(/<[^>]*>/g, "");
+        // Strip any remaining tags. This has to repeat until stable: a single
+        // pass is not a fixed point, because removing one match can splice its
+        // neighbours into a fresh tag ("<<p>p>" collapses to "<p>"). The input
+        // here is already built by generateSafeHTMLFromFormData, which escapes
+        // every form field, so this is defense in depth rather than the only
+        // barrier — but a lone replace is the exact idiom that fails.
+        let previous: string;
+        do {
+          previous = md;
+          md = md.replace(/<[^>]*>/g, "");
+        } while (md !== previous);
 
         return md;
       };
@@ -517,8 +526,10 @@ export default function PolicyGenerator({
             pdf.text(textLines, 20, 30);
 
             // Get PDF as blob
+            // pdf.output("blob") already carries the application/pdf type, and
+            // the shared download path below reads only `blob` and
+            // `fileExtension` — so setting mimeType here would never be read.
             blob = pdf.output("blob");
-            mimeType = "application/pdf";
             fileExtension = "pdf";
             break;
 

--- a/src/components/privacy-policy/steps/DataCollectionStep.tsx
+++ b/src/components/privacy-policy/steps/DataCollectionStep.tsx
@@ -5,7 +5,6 @@ import CheckboxGroup from '../shared/CheckboxGroup';
 import FormField from '../shared/FormField';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/Card';
 import { Select } from '@/components/ui/Select';
-import { cn } from '@/lib/utils';
 
 interface DataCollectionStepProps {
   formData: {

--- a/src/components/privacy-policy/steps/DataSharingStep.tsx
+++ b/src/components/privacy-policy/steps/DataSharingStep.tsx
@@ -6,7 +6,6 @@ import CheckboxGroup from '../shared/CheckboxGroup';
 import FormField from '../shared/FormField';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/Card';
 import { TextArea } from '@/components/ui/TextArea';
-import { cn } from '@/lib/utils';
 
 interface DataSharingStepProps {
   formData: {

--- a/src/components/privacy-policy/steps/OrganizationInfoStep.tsx
+++ b/src/components/privacy-policy/steps/OrganizationInfoStep.tsx
@@ -6,7 +6,6 @@ import { Input } from '@/components/ui/Input';
 import { TextArea } from '@/components/ui/TextArea';
 import { Checkbox } from '@/components/ui/Checkbox';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/Card';
-import { cn } from '@/lib/utils';
 
 interface OrganizationInfoStepProps {
   formData: {

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -17,6 +17,22 @@ export interface BlogPost {
 
 const BLOG_DIR = path.join(process.cwd(), 'content/blog');
 
+/**
+ * Blog slugs come from filenames on disk and are then used two ways: joined
+ * onto BLOG_DIR to read a file, and interpolated into `/blog/${slug}` hrefs.
+ * Constraining them to lowercase kebab-case makes both uses safe by
+ * construction — a slug can carry no `.` or path separator to escape BLOG_DIR,
+ * and no `:` to introduce a URL scheme in an href (CodeQL js/stored-xss).
+ *
+ * Every post currently in content/blog already conforms, so this documents and
+ * enforces the existing convention rather than changing behavior.
+ */
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export function isValidBlogSlug(slug: string): boolean {
+  return SLUG_PATTERN.test(slug);
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -64,14 +80,22 @@ export function getAllPosts(): BlogPost[] {
 
   return files
     .map(filename => {
-      const slug = filename.replace('.mdx', '');
+      // slice, not replace('.mdx', '') — replace strips the first occurrence
+      // anywhere in the name, so "notes.mdx.mdx" would yield "notes.mdx".
+      const slug = filename.slice(0, -'.mdx'.length);
+      if (!isValidBlogSlug(slug)) return null;
       const fileContent = fs.readFileSync(path.join(BLOG_DIR, filename), 'utf-8');
       return toBlogPost(slug, fileContent);
     })
+    .filter((post): post is BlogPost => post !== null)
     .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 }
 
 export function getPostBySlug(slug: string): BlogPost | null {
+  // Validate before touching the filesystem so a slug can never join its way
+  // out of BLOG_DIR.
+  if (!isValidBlogSlug(slug)) return null;
+
   const filePath = path.join(BLOG_DIR, `${slug}.mdx`);
   if (!fs.existsSync(filePath)) return null;
 

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -1,10 +1,32 @@
 /**
- * Sanitization utilities for preventing XSS attacks
- * In production, consider using a library like DOMPurify
+ * Sanitization utilities for the docs site.
+ *
+ * This module deliberately contains only `escapeHtml`. It previously also
+ * exported `sanitizeInput`, `sanitizeEmail`, `sanitizeFileName`,
+ * `markdownToSafeHtml`, and `sanitizeUrl`, none of which had a single caller
+ * anywhere in the repository, and all of which were built from denylist regexes
+ * that CodeQL correctly flagged as unsound:
+ *
+ * - the `<script>…</script>` strip missed `</script >` and could reassemble the
+ *   tag out of surviving fragments (js/bad-tag-filter,
+ *   js/incomplete-multi-character-sanitization)
+ * - the `on*` handler strip only matched quoted values, so `onerror=alert(1)`
+ *   passed straight through (js/incomplete-multi-character-sanitization)
+ * - the scheme strip removed `javascript:` but not `data:` or `vbscript:`
+ *   (js/incomplete-url-scheme-check)
+ * - the email tag strip had the same single-pass reassembly flaw
+ *
+ * Deleting them is strictly safer than patching them. Unused, subtly broken
+ * sanitizers are a trap: the next caller reasonably assumes the name means what
+ * it says. Anything needing real HTML sanitization should use the `dompurify`
+ * dependency the workspace already pins, and anything needing escaping for text
+ * display should use `escapeHtml` below, which escapes the full set and has no
+ * bypass.
  */
 
 /**
- * Escapes HTML special characters to prevent XSS
+ * Escapes the five HTML-significant characters so a value is inert when placed
+ * in element text or a quoted attribute.
  */
 export function escapeHtml(unsafe: string): string {
   return unsafe
@@ -13,96 +35,4 @@ export function escapeHtml(unsafe: string): string {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#039;");
-}
-
-/**
- * Sanitizes user input for safe display
- * Removes dangerous tags and attributes
- */
-export function sanitizeInput(input: string): string {
-  // Remove script tags and their content
-  let sanitized = input.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
-  
-  // Remove on* event handlers
-  sanitized = sanitized.replace(/\s*on\w+\s*=\s*["'][^"']*["']/gi, '');
-  
-  // Remove javascript: protocol
-  sanitized = sanitized.replace(/javascript:/gi, '');
-  
-  // Escape remaining HTML
-  return escapeHtml(sanitized);
-}
-
-/**
- * Validates and sanitizes email addresses
- */
-export function sanitizeEmail(email: string): string {
-  // Basic email validation
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  
-  if (!emailRegex.test(email)) {
-    throw new Error('Invalid email format');
-  }
-  
-  // Remove any HTML tags
-  return email.replace(/<[^>]*>/g, '').trim().toLowerCase();
-}
-
-/**
- * Sanitizes file names to prevent directory traversal attacks
- */
-export function sanitizeFileName(fileName: string): string {
-  // Remove path separators and null bytes
-  return fileName
-    .replace(/[\/\\]/g, '')
-    .replace(/\0/g, '')
-    .replace(/\.{2,}/g, '.')
-    .trim();
-}
-
-/**
- * Creates a safe HTML structure from markdown
- * This is a basic implementation - for production use a proper markdown parser
- */
-export function markdownToSafeHtml(markdown: string): string {
-  let html = escapeHtml(markdown);
-  
-  // Convert markdown syntax to HTML
-  html = html
-    // Headers
-    .replace(/^### (.*$)/gim, '<h3>$1</h3>')
-    .replace(/^## (.*$)/gim, '<h2>$1</h2>')
-    .replace(/^# (.*$)/gim, '<h1>$1</h1>')
-    // Bold
-    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
-    // Italic
-    .replace(/\*([^*]+)\*/g, '<em>$1</em>')
-    // Line breaks
-    .replace(/\n/g, '<br />');
-  
-  return html;
-}
-
-/**
- * Validates and sanitizes URL to prevent open redirect vulnerabilities
- */
-export function sanitizeUrl(url: string, allowedHosts?: string[]): string {
-  try {
-    const parsed = new URL(url);
-    
-    // Check if protocol is safe
-    if (!['http:', 'https:'].includes(parsed.protocol)) {
-      throw new Error('Invalid protocol');
-    }
-    
-    // Check if host is allowed
-    if (allowedHosts && !allowedHosts.includes(parsed.hostname)) {
-      throw new Error('Host not allowed');
-    }
-    
-    return parsed.toString();
-  } catch {
-    // If URL parsing fails, return a safe default
-    return '#';
-  }
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -127,9 +127,23 @@ export default defineConfig({
     // published bundle we strip it (idempotent) then re-inject ONLY for
     // client entries, post-minify.
 
+    // Both helpers read directly and tolerate ENOENT instead of calling
+    // existsSync first. A separate existence check is a TOCTOU pattern
+    // (CodeQL js/file-system-race) and buys nothing here: the read can fail
+    // whether or not it is preceded by a check, so handling the failure is
+    // the only thing that actually helps.
+    const readIfPresent = (filePath: string): string | null => {
+      try {
+        return fs.readFileSync(filePath, "utf8");
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+        throw err;
+      }
+    };
+
     const stripUseClient = (filePath: string) => {
-      if (!fs.existsSync(filePath)) return;
-      const original = fs.readFileSync(filePath, "utf8");
+      const original = readIfPresent(filePath);
+      if (original === null) return;
       const stripped = original.replace(/^["']use client["'];?\s*\n?/, "");
       if (stripped !== original) {
         fs.writeFileSync(filePath, stripped, "utf8");
@@ -137,8 +151,8 @@ export default defineConfig({
     };
 
     const injectUseClient = (filePath: string) => {
-      if (!fs.existsSync(filePath)) return;
-      const original = fs.readFileSync(filePath, "utf8");
+      const original = readIfPresent(filePath);
+      if (original === null) return;
       // Idempotent: don't double-prepend if a previous build (or the
       // banner that did survive on this entry by accident) already left
       // the directive in place.


### PR DESCRIPTION
66 CodeQL alerts were open: **18 high, 1 medium, 2 warning, 45 note**. Four high plus the medium are in the published package, so they shipped to users.

(My earlier count of 13 was wrong — I'd queried the API without `--paginate` and only saw the first page.)

## Published package

**`js/polynomial-redos` ×4** — the `{{var}}` matchers used `[^}]+` / `[^}\s]+`. A run of `{` gets consumed in full before the closing `}}` fails to match, and since the leading `\{\{` retries at every offset in that run, the scan is quadratic. Section templates and rendered policy text are library input, so a malformed template could stall an export. Excluding `{` from the class makes `{{{{…` fail at the first character.

- `utils/privacy.ts` — `findUnfilledTokens`, both `generatePolicyText` branches
- `utils/policy-export/html.ts` — `substituteVariables`

**`js/html-constructed-from-input`** — `exportHTML` guarded consumer `customCSS` with `replace(/<\/style>/gi, '')`. `<style>` is a raw-text element: the parser ends it at the first `</style` followed by whitespace, `/`, or `>`. So every one of these escaped the block and became live markup:

```
</style ><img src=x onerror=alert(1)>
</style/><img src=x onerror=alert(1)>
</style\n><img src=x onerror=alert(1)>
```

Deleting the `</style` token instead is *also* unsound — one pass can reassemble it from fragments, since `</st</styleyle` loses its middle match and collapses into a working `</styleyle`.

The fix escapes every `<` as the CSS escape `\3C`, which is total: CSS has no syntactic use for `<` outside a string, comment, or `url()`; the replacement introduces no new `<`; and `>` is untouched so child combinators keep working.

## Docs site

`src/lib/sanitize.ts` held five denylist sanitizers responsible for five high alerts between them:

| Function | Flaw |
|---|---|
| `sanitizeInput` | `<script>` strip missed `</script >` and could reassemble; `on*` strip only matched *quoted* values, so `onerror=alert(1)` passed through; scheme strip removed `javascript:` but not `data:` or `vbscript:` |
| `sanitizeEmail` | same single-pass tag-strip reassembly flaw |
| `sanitizeFileName`, `markdownToSafeHtml`, `sanitizeUrl` | unused |

**None had a single caller anywhere in the repo.** Deleted rather than patched — an unused, subtly broken sanitizer is a trap, because the next caller reasonably assumes the name means what it says. Only `escapeHtml` remains, which is the one function actually imported (by `PolicyGenerator.tsx`) and has no bypass.

**`js/stored-xss` ×6** — blog slugs came from filenames and flowed unchecked into `/blog/${slug}` hrefs *and* into `path.join(BLOG_DIR, …)`. Added a kebab-case pattern enforced in both `getAllPosts` and `getPostBySlug`, making both uses safe by construction and closing a latent path-traversal shape in the lookup. All 21 existing posts already conform, so this enforces the existing convention rather than changing behavior. Also switched the extension strip from `replace('.mdx', '')` — which removes the first occurrence *anywhere* — to a `slice`.

Remaining: `PolicyGenerator`'s tag strip now iterates to a fixed point instead of assuming one pass suffices; its dead `mimeType` assignment in the PDF branch is gone (jsPDF's blob already carries the type); `ErrorBoundary` no longer stores an `error` that `render` never reads.

## Build config

`tsup.config.ts` checked `existsSync` then `readFileSync` in both `"use client"` helpers. Replaced with a shared `readIfPresent` that tolerates `ENOENT` — the separate check was a race and bought nothing, since the read can fail either way.

## Root cause of the 45 note-level alerts

`@typescript-eslint/no-unused-vars` was **`"off"`**. Lint never objected to unused imports and locals, so 45 accumulated for CodeQL to find. Enabled as an error with the usual `^_` escape hatches — lint is now the gate and they can't come back — then fixed all 65 resulting errors: unused imports, dead helpers, state tuples where only one half is used, a caught binding never read, and unused map/`forEach` index params.

`create-ndpr/templates/**` is exempted. Those are Handlebars sources where a declaration can be referenced only from inside a `{{#if}}` branch a given render strips, so "unused" isn't a reliable signal — the same reason the CodeQL config already excludes them. The rendered output is what gets strictly typechecked, by `verify:create-ndpr`.

## Found along the way: five props that do nothing

`DSRTracker.buttonClassName`, `PolicyGenerator.showPreview`, `PolicyPreview.sections`, `PolicyPreview.variables`, and `useBreach({ categories })` are all declared on public types but never applied by their implementations. A user setting them gets silence.

They're left out of the destructuring with a comment saying so, rather than bound and silently ignored — callers are unaffected because the types are unchanged. **Implementing them is a design decision, not a lint fix**, so I've left that call to you.

## Verification

Full `pnpm verify:ci`:

- **116 suites / 1482 tests** passed, up from 1468 — 14 new tests cover the eight `</style` breakout variants including fragment reassembly, child-combinator preservation, the `includeStyles: false` path, and linear-time scanning of pathological brace runs
- `eslint .` clean under the newly-enabled rule
- `build:lib`, `typecheck:recipes`, `tsc --noEmit`, `typecheck:storybook`
- `verify:create-ndpr` — 15 framework/layout/ORM combinations
- `build:storybook`, and `verify:tarball` across all 22 subpaths in ESM, CJS, TypeScript

Worth recording: root `tsc --noEmit` does **not** cover `packages/ndpr-toolkit/src` — only the tsup DTS build does. An early version of this branch removed a prop that was used in five places and root `tsc` passed; `build:lib` is what caught it.