### PR TITLE
chore(examples): move all 14 examples to the 6.x toolkit line

### DIFF
--- a/examples/dsr-backend-reference/package.json
+++ b/examples/dsr-backend-reference/package.json
@@ -10,7 +10,7 @@
     "prisma:migrate": "prisma migrate dev"
   },
   "dependencies": {
-    "@tantainnovative/ndpr-toolkit": "^5.1.1",
+    "@tantainnovative/ndpr-toolkit": "^6.0.0",
     "next": "^15.5.18",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/examples/ecommerce-starter/app/checkout/page.tsx
+++ b/examples/ecommerce-starter/app/checkout/page.tsx
@@ -1,3 +1,9 @@
+// This page is interactive: the demo form cancels its own submit with an
+// onSubmit handler. Event handlers can't be passed from a Server Component to a
+// client element, so prerendering /checkout failed with "Event handlers cannot
+// be passed to Client Component props" until this directive was added.
+"use client";
+
 import Link from "next/link";
 
 const pageStyle: React.CSSProperties = {

--- a/examples/ecommerce-starter/package.json
+++ b/examples/ecommerce-starter/package.json
@@ -8,7 +8,9 @@
     "start": "next start"
   },
   "dependencies": {
-    "@tantainnovative/ndpr-toolkit": "^5.1.1",
+    "@tantainnovative/ndpr-toolkit": "^6.0.0",
+    "docx": "^9.5.1",
+    "jspdf": "^4.2.1",
     "next": "^15.5.18",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/examples/nextjs-app/package.json
+++ b/examples/nextjs-app/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@tantainnovative/ndpr-toolkit": "^5.1.1",
+    "@tantainnovative/ndpr-toolkit": "^6.0.0",
     "next": "^15.5.18",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/examples/ssr/astro/package.json
+++ b/examples/ssr/astro/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@astrojs/node": "^11.0.3",
     "@astrojs/react": "^6.0.2",
-    "@tantainnovative/ndpr-toolkit": "^5.1.1",
+    "@tantainnovative/ndpr-toolkit": "^6.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "astro": "^7.1.6",

--- a/examples/ssr/nextjs-app-router/package.json
+++ b/examples/ssr/nextjs-app-router/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@tantainnovative/ndpr-toolkit": "^5.1.1",
+    "@tantainnovative/ndpr-toolkit": "^6.0.0",
     "next": "^15.5.18",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/examples/ssr/remix/app/vite-env.d.ts
+++ b/examples/ssr/remix/app/vite-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+// Brings in Vite's declarations for asset-query imports, which is what makes
+// `import toolkitStyles from "@tantainnovative/ndpr-toolkit/styles?url"` in
+// root.tsx typecheck. Without it TypeScript sees the `?url` suffix as part of
+// the module specifier and reports TS2307, even though Vite resolves it fine at
+// build time — so `npx tsc --noEmit` failed here while `npm run build` passed.

--- a/examples/ssr/remix/package.json
+++ b/examples/ssr/remix/package.json
@@ -14,7 +14,7 @@
     "@remix-run/node": "^2.13.0",
     "@remix-run/react": "^2.13.0",
     "@remix-run/serve": "^2.13.0",
-    "@tantainnovative/ndpr-toolkit": "^5.1.1",
+    "@tantainnovative/ndpr-toolkit": "^6.0.0",
     "isbot": "^4.4.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"

--- a/examples/stackblitz/breach/package.json
+++ b/examples/stackblitz/breach/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@tantainnovative/ndpr-toolkit": "^5.1.1",
+    "@tantainnovative/ndpr-toolkit": "^6.0.0",
     "next": "^15.5.18",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/examples/stackblitz/consent/package.json
+++ b/examples/stackblitz/consent/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@tantainnovative/ndpr-toolkit": "^5.1.1",
+    "@tantainnovative/ndpr-toolkit": "^6.0.0",
     "next": "^15.5.18",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/examples/stackblitz/cross-border/package.json
+++ b/examples/stackblitz/cross-border/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@tantainnovative/ndpr-toolkit": "^5.1.1",
+    "@tantainnovative/ndpr-toolkit": "^6.0.0",
     "next": "^15.5.18",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/examples/stackblitz/dpia/package.json
+++ b/examples/stackblitz/dpia/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@tantainnovative/ndpr-toolkit": "^5.1.1",
+    "@tantainnovative/ndpr-toolkit": "^6.0.0",
     "next": "^15.5.18",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/examples/stackblitz/dsr/package.json
+++ b/examples/stackblitz/dsr/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@tantainnovative/ndpr-toolkit": "^5.1.1",
+    "@tantainnovative/ndpr-toolkit": "^6.0.0",
     "next": "^15.5.18",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/examples/stackblitz/lawful-basis/package.json
+++ b/examples/stackblitz/lawful-basis/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@tantainnovative/ndpr-toolkit": "^5.1.1",
+    "@tantainnovative/ndpr-toolkit": "^6.0.0",
     "next": "^15.5.18",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/examples/stackblitz/policy/package.json
+++ b/examples/stackblitz/policy/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@tantainnovative/ndpr-toolkit": "^5.1.1",
+    "@tantainnovative/ndpr-toolkit": "^6.0.0",
     "docx": "^9.0.0",
     "jspdf": "^4.2.1",
     "next": "^15.5.18",

--- a/examples/stackblitz/ropa/package.json
+++ b/examples/stackblitz/ropa/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@tantainnovative/ndpr-toolkit": "^5.1.1",
+    "@tantainnovative/ndpr-toolkit": "^6.0.0",
     "next": "^15.5.18",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "build": "next build && node scripts/post-build.js",
     "build:lib": "tsup && cp packages/ndpr-toolkit/src/styles.d.ts dist/styles.d.ts && node scripts/rollup-dts.mjs",
     "verify:tarball": "node scripts/verify-tarball.mjs",
+    "verify:examples": "node scripts/verify-examples.mjs",
     "verify:create-ndpr": "node scripts/verify-create-ndpr.mjs",
     "verify:create-ndpr:codeql": "node scripts/verify-create-ndpr.mjs --codeql",
     "prepublishOnly": "pnpm build:lib",

--- a/scripts/verify-examples.mjs
+++ b/scripts/verify-examples.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Typecheck every examples/** app against the toolkit version it pins.
+ *
+ * Each example is copied to a temp directory OUTSIDE the repository before
+ * installing. That matters: built in place, Vite/PostCSS walk up and pick up the
+ * monorepo root postcss.config.mjs, whose Tailwind plugin is absent from the
+ * example's isolated node_modules. A standalone consumer has no parent config,
+ * so the copy is the honest environment.
+ *
+ * examples/** is deliberately outside the pnpm workspace (see
+ * pnpm-workspace.yaml) and no CI job builds these, so this is the only thing
+ * that checks they still compile against a published toolkit.
+ *
+ * Usage: node scripts/verify-examples.mjs [--build] [filter]
+ */
+import { execFileSync } from 'node:child_process';
+import { cpSync, mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative } from 'node:path';
+import { globSync } from 'node:fs';
+
+const args = process.argv.slice(2);
+const doBuild = args.includes('--build');
+const filter = args.find((a) => !a.startsWith('--'));
+
+const manifests = globSync('examples/**/package.json', { exclude: (p) => p.includes('node_modules') })
+  .filter((p) => !p.includes('node_modules'))
+  .sort();
+
+const results = [];
+
+for (const manifest of manifests) {
+  const dir = manifest.replace(/\/package\.json$/, '');
+  if (filter && !dir.includes(filter)) continue;
+
+  const pkg = JSON.parse(readFileSync(manifest, 'utf8'));
+  const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+  const pinned = deps['@tantainnovative/ndpr-toolkit'] ?? '(none)';
+
+  const tmp = mkdtempSync(join(tmpdir(), 'ndpr-ex-'));
+  let status = 'ok';
+  let detail = '';
+
+  try {
+    cpSync(dir, tmp, { recursive: true });
+    for (const junk of ['node_modules', 'dist', '.next', '.astro', 'build']) {
+      rmSync(join(tmp, junk), { recursive: true, force: true });
+    }
+
+    execFileSync('npm', ['install', '--no-audit', '--no-fund'], {
+      cwd: tmp,
+      stdio: 'pipe',
+      encoding: 'utf8',
+    });
+
+    // Confirm the toolkit actually resolved to a v6 line.
+    const installed = JSON.parse(
+      readFileSync(join(tmp, 'node_modules/@tantainnovative/ndpr-toolkit/package.json'), 'utf8'),
+    ).version;
+    detail = `toolkit@${installed}`;
+
+    if (existsSync(join(tmp, 'tsconfig.json'))) {
+      execFileSync('npx', ['tsc', '--noEmit'], { cwd: tmp, stdio: 'pipe', encoding: 'utf8' });
+    } else {
+      detail += ' (no tsconfig — typecheck skipped)';
+    }
+
+    if (doBuild && pkg.scripts?.build) {
+      execFileSync('npm', ['run', 'build'], { cwd: tmp, stdio: 'pipe', encoding: 'utf8' });
+      detail += ' + build';
+    }
+  } catch (err) {
+    status = 'FAIL';
+    const out = `${err.stdout ?? ''}${err.stderr ?? ''}`.trim();
+    detail = out.split('\n').slice(0, 14).join('\n      ') || err.message;
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+
+  results.push({ dir, pinned, status, detail });
+  const mark = status === 'ok' ? 'ok  ' : 'FAIL';
+  console.log(`${mark} ${dir}  (pins ${pinned})  ${status === 'ok' ? detail : ''}`);
+  if (status === 'FAIL') console.log(`      ${detail}`);
+}
+
+const failed = results.filter((r) => r.status !== 'ok');
+console.log(`\n${results.length - failed.length}/${results.length} examples verified`);
+if (failed.length) {
+  console.log('failed:', failed.map((f) => f.dir).join(', '));
+  process.exit(1);
+}


### PR DESCRIPTION
Every example pinned `@tantainnovative/ndpr-toolkit: ^5.1.1`, so each resolved to **5.7.4** and none demonstrated 6.0.0 — including `examples/nextjs-app`, which the README's StackBlitz and CodeSandbox buttons open.

Nothing in CI builds these (`examples/**` is outside the pnpm workspace and eslint-ignored). That's how they drifted a whole major behind, and why the two build failures below went unnoticed.

## The upgrade needed no source changes

No example calls `assessBreachNotification` or passes the force-on-only `highRisk` / `notificationRequired` options, and every toolkit import is a preset, adapter, hook, or stylesheet — none of which 6.0 renamed or removed:

```
 13  @tantainnovative/ndpr-toolkit
  9  .../presets          4  .../adapters        3  .../presets/dsr
  3  .../consent          2  .../server          2  .../presets/policy
  2  .../presets/consent  1  .../styles?url      1  .../hooks
```

## Two pre-existing failures fixed along the way

Both confirmed against the **old `^5.1.1` pin** first, so neither is fallout from the bump.

**`ssr/remix`** failed `tsc --noEmit`:

```
app/root.tsx(10,27): error TS2307: Cannot find module
  '@tantainnovative/ndpr-toolkit/styles?url' or its corresponding type declarations.
```

`?url` is a Vite asset query, and the app had no `vite/client` reference, so TypeScript read the suffix as part of the module specifier. Added `app/vite-env.d.ts`. The *build* always passed, which is why only a typecheck surfaced it.

**`ecommerce-starter`** could not build at all. It uses the policy preset, which reaches the PDF and DOCX export paths, but never declared the toolkit's **optional** `jspdf` and `docx` peers — webpack couldn't resolve either. With those added the build got as far as prerendering `/checkout`, which then failed:

```
Error: Event handlers cannot be passed to Client Component props.
  {onSubmit: function onSubmit, children: ...}
```

The page is a Server Component but hands `onSubmit` to its demo form. Marked it `"use client"`, which matches what the page is actually doing.

## New: a way to check any of this

Adds `scripts/verify-examples.mjs` and a `verify:examples` script, because there wasn't one.

It copies each example to a temp directory **outside the repository** before installing. That detail matters: built in place, Vite and PostCSS walk up and find the monorepo root `postcss.config.mjs`, whose Tailwind plugin is absent from the example's isolated `node_modules` — so an in-place build fails for a reason that has nothing to do with the example. A standalone consumer has no parent config, so the copy is the honest environment. It then installs, asserts the toolkit resolved to the pinned line, runs `tsc --noEmit`, and with `--build` runs the real build.

**Not wired into CI** — 14 npm installs plus 14 builds is too slow for every PR. Run it before a release, or after touching an example.

## Verification

```
$ node scripts/verify-examples.mjs --build

ok   examples/dsr-backend-reference     (pins ^6.0.0)  toolkit@6.0.0 + build
ok   examples/ecommerce-starter         (pins ^6.0.0)  toolkit@6.0.0 + build
ok   examples/nextjs-app                (pins ^6.0.0)  toolkit@6.0.0 + build
ok   examples/ssr/astro                 (pins ^6.0.0)  toolkit@6.0.0 + build
ok   examples/ssr/nextjs-app-router     (pins ^6.0.0)  toolkit@6.0.0 + build
ok   examples/ssr/remix                 (pins ^6.0.0)  toolkit@6.0.0 + build
ok   examples/stackblitz/breach         (pins ^6.0.0)  toolkit@6.0.0 + build
ok   examples/stackblitz/consent        (pins ^6.0.0)  toolkit@6.0.0 + build
ok   examples/stackblitz/cross-border   (pins ^6.0.0)  toolkit@6.0.0 + build
ok   examples/stackblitz/dpia           (pins ^6.0.0)  toolkit@6.0.0 + build
ok   examples/stackblitz/dsr            (pins ^6.0.0)  toolkit@6.0.0 + build
ok   examples/stackblitz/lawful-basis   (pins ^6.0.0)  toolkit@6.0.0 + build
ok   examples/stackblitz/policy         (pins ^6.0.0)  toolkit@6.0.0 + build
ok   examples/stackblitz/ropa           (pins ^6.0.0)  toolkit@6.0.0 + build

14/14 examples verified
```

## Left alone deliberately

Eleven examples still pin `next: ^15.5.18` while the toolkit itself is on Next 16. The toolkit declares no `next` peer — only `react ^18 || ^19` — so Next 15 is fine and all 14 build green on it. Bumping them to Next 16 is a separate change with its own breakage surface, and it isn't needed for these to demonstrate 6.0.