### PR TITLE
chore(lint): extend no-unused-vars to plain-JS tooling

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -61,6 +61,29 @@ const eslintConfig = [
       "@typescript-eslint/no-explicit-any": "off",
     },
   },
+  // Plain-JS tooling: scripts/, bin/, hooks and config helpers. The TS block
+  // above only matches **/*.{ts,tsx}, so .mjs/.js files were linted with no
+  // rules at all — which is how an unused import in scripts/verify-examples.mjs
+  // reached main and got reported by CodeQL instead of by lint.
+  {
+    files: ["**/*.{js,mjs,cjs}"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+    },
+    plugins: { "@typescript-eslint": tsPlugin },
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          ignoreRestSiblings: true,
+        },
+      ],
+    },
+  },
   // tests exercise the CJS entry points and jest mocks via require()
   {
     files: ["**/__tests__/**", "**/*.test.{ts,tsx}"],

--- a/scripts/verify-examples.mjs
+++ b/scripts/verify-examples.mjs
@@ -15,10 +15,9 @@
  * Usage: node scripts/verify-examples.mjs [--build] [filter]
  */
 import { execFileSync } from 'node:child_process';
-import { cpSync, mkdtempSync, rmSync, existsSync, readFileSync } from 'node:fs';
+import { cpSync, mkdtempSync, rmSync, existsSync, readFileSync, globSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, relative } from 'node:path';
-import { globSync } from 'node:fs';
+import { join } from 'node:path';
 
 const args = process.argv.slice(2);
 const doBuild = args.includes('--build');


### PR DESCRIPTION
Closes the last open CodeQL alert, and the gap that produced it.

#130 enabled `@typescript-eslint/no-unused-vars`, but only inside a config block matching `**/*.{ts,tsx}`. Every `.mjs`, `.js`, and `.cjs` file in the repo was therefore linted with **no rules at all**.

So when #135 added `scripts/verify-examples.mjs` with an unused `relative` import, lint passed, the branch merged, and CodeQL reported it on `main`:

```
[note] js/unused-local-variable  scripts/verify-examples.mjs:20
```

That's precisely the gap #130 set out to close — one file extension over.

## Changes

- New ESLint block for `**/*.{js,mjs,cjs}` applying the same `no-unused-vars` config as the TS block
- Dropped the unused `relative` import and merged its duplicate `node:fs` import

`eslint .` is clean across the whole repo afterwards, so nothing else in the JS tooling was hiding.

## Verification

- `eslint .` clean
- `node scripts/verify-examples.mjs stackblitz/consent` still runs — 1/1 verified, `toolkit@6.0.0`
- Full `pnpm verify:ci`: 116 suites / 1482 tests

With this merged, open CodeQL alerts go to **zero**, from 66 at the start of this work.