### PR TITLE
fix(policy): make showPreview work, and mark the other dead props deprecated

### DIFF
--- a/packages/ndpr-toolkit/src/__tests__/components/policy/PolicyGenerator-showPreview.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/components/policy/PolicyGenerator-showPreview.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * `showPreview` regression suite.
+ *
+ * The prop was declared on PolicyGeneratorProps and documented as "Whether to
+ * show a preview of the generated policy / @default true", but nothing in the
+ * component ever read it — so `showPreview={false}` silently still showed the
+ * preview step. These tests pin the implemented behavior in both directions.
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PolicyGenerator } from '../../../components/policy/PolicyGenerator';
+import type { PolicySection, PolicyVariable } from '../../../types/privacy';
+
+const sections: PolicySection[] = [
+  {
+    id: 'intro',
+    title: 'Introduction',
+    content: '',
+    template: 'We are {{orgName}}.',
+    required: true,
+    included: true,
+    order: 1,
+  },
+];
+
+// `value` is already populated so validateVariables passes and the generate
+// button is reachable without filling the form.
+const variables: PolicyVariable[] = [
+  {
+    id: 'orgName',
+    name: 'orgName',
+    description: 'Organisation name',
+    value: 'Tanta Innovative',
+    required: true,
+    type: 'text',
+  } as PolicyVariable,
+];
+
+/** Walk the wizard from the sections step to the variables step. */
+function goToVariables() {
+  fireEvent.click(screen.getByRole('button', { name: /continue|next|variables/i }));
+}
+
+describe('PolicyGenerator — showPreview', () => {
+  it('defaults to true: generating lands on the preview step and waits for Save', () => {
+    const onGenerate = jest.fn();
+    render(
+      <PolicyGenerator sections={sections} variables={variables} onGenerate={onGenerate} />,
+    );
+
+    expect(screen.getByText('Preview')).toBeInTheDocument();
+
+    goToVariables();
+    fireEvent.click(screen.getByRole('button', { name: /generate policy/i }));
+
+    // Preview is shown and nothing is emitted until the user confirms.
+    expect(screen.getByRole('heading', { name: /preview generated policy/i })).toBeInTheDocument();
+    expect(onGenerate).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /save policy/i }));
+    expect(onGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it('showPreview={false}: generating emits immediately and skips the preview step', () => {
+    const onGenerate = jest.fn();
+    render(
+      <PolicyGenerator
+        sections={sections}
+        variables={variables}
+        showPreview={false}
+        onGenerate={onGenerate}
+      />,
+    );
+
+    // The step indicator drops the third step entirely.
+    expect(screen.queryByText('Preview')).not.toBeInTheDocument();
+
+    goToVariables();
+    fireEvent.click(screen.getByRole('button', { name: /generate policy/i }));
+
+    expect(onGenerate).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByRole('heading', { name: /preview generated policy/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('showPreview={false}: emits the freshly generated content, not stale state', () => {
+    // generatePolicy calls onGenerate in the same tick as setGeneratedPolicy, so
+    // reading component state there would submit the previous (empty) value.
+    // The implementation passes the local policyContent instead.
+    const onGenerate = jest.fn();
+    render(
+      <PolicyGenerator
+        sections={sections}
+        variables={variables}
+        showPreview={false}
+        onGenerate={onGenerate}
+      />,
+    );
+
+    goToVariables();
+    fireEvent.click(screen.getByRole('button', { name: /generate policy/i }));
+
+    const payload = onGenerate.mock.calls[0][0];
+    expect(payload.content).toContain('## Introduction');
+    expect(payload.content).toContain('We are Tanta Innovative.');
+    expect(payload.content).not.toBe('');
+    expect(payload.sections).toHaveLength(1);
+    expect(payload.variables).toHaveLength(1);
+  });
+
+  it('showPreview={false} still blocks generation when a required variable is empty', () => {
+    const onGenerate = jest.fn();
+    render(
+      <PolicyGenerator
+        sections={sections}
+        variables={[{ ...variables[0], value: '' }]}
+        showPreview={false}
+        onGenerate={onGenerate}
+      />,
+    );
+
+    goToVariables();
+    fireEvent.click(screen.getByRole('button', { name: /generate policy/i }));
+
+    expect(onGenerate).not.toHaveBeenCalled();
+    expect(screen.getByText(/orgName is required/i)).toBeInTheDocument();
+  });
+});

--- a/packages/ndpr-toolkit/src/__tests__/hooks/useBreach-adapter.test.tsx
+++ b/packages/ndpr-toolkit/src/__tests__/hooks/useBreach-adapter.test.tsx
@@ -129,3 +129,33 @@ describe('useBreach with adapter', () => {
     expect('isLoading' in result.current).toBe(true);
   });
 });
+
+
+describe('useBreach — categories is optional', () => {
+  // `categories` was a *required* option that the hook never read, so every
+  // caller had to construct an array only for it to be ignored. It is now
+  // optional and deprecated. Existing call sites that still pass it keep
+  // compiling — the tests above are exactly that case.
+  it('works with categories omitted entirely', async () => {
+    const adapter = memoryAdapter<any>();
+    const { result } = renderHook(() => useBreach({ adapter }));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.reports).toEqual([]);
+    expect(result.current.assessments).toEqual([]);
+    expect(result.current.notifications).toEqual([]);
+  });
+
+  it('still reports a breach with categories omitted', async () => {
+    const adapter = memoryAdapter<any>();
+    const { result } = renderHook(() => useBreach({ adapter }));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.reportBreach(baseReportData as any);
+    });
+
+    await waitFor(() => expect(result.current.reports).toHaveLength(1));
+  });
+});

--- a/packages/ndpr-toolkit/src/components/dsr/DSRTracker.tsx
+++ b/packages/ndpr-toolkit/src/components/dsr/DSRTracker.tsx
@@ -45,6 +45,12 @@ export interface DSRTrackerProps {
   
   /**
    * Custom CSS class for the buttons
+   *
+   * @deprecated This component renders no buttons — its only control is the
+   * timeframe `<select>` — so this prop has never had any effect. Use
+   * `classNames` to target specific elements, or `unstyled` to drop the default
+   * Tailwind classes entirely. Kept on the type so existing call sites still
+   * compile; it will be removed in the next major.
    */
   buttonClassName?: string;
   

--- a/packages/ndpr-toolkit/src/components/policy/PolicyGenerator.tsx
+++ b/packages/ndpr-toolkit/src/components/policy/PolicyGenerator.tsx
@@ -115,9 +115,7 @@ export const PolicyGenerator: React.FC<PolicyGeneratorProps> = ({
   className = "",
   buttonClassName = "",
   generateButtonText,
-  // showPreview is accepted by PolicyGeneratorProps but not currently applied by
-  // this component. Left out of the destructure rather than bound and ignored;
-  // callers are unaffected because the prop stays on the type.
+  showPreview = true,
   allowEditing = true,
   classNames,
   unstyled = false
@@ -219,6 +217,16 @@ export const PolicyGenerator: React.FC<PolicyGeneratorProps> = ({
     setGeneratedPolicy(policyContent);
     setEditedPolicy(policyContent);
     setIsGenerated(true);
+
+    // With showPreview disabled there is no preview step to advance to, so the
+    // policy is handed straight to onGenerate. `policyContent` is passed rather
+    // than reading generatedPolicy/editedPolicy, because those setState calls
+    // have not landed yet in this tick and would submit stale content.
+    if (!showPreview) {
+      onGenerate({ sections, variables, content: policyContent });
+      return;
+    }
+
     setActiveStep('preview');
   };
   
@@ -512,13 +520,15 @@ export const PolicyGenerator: React.FC<PolicyGeneratorProps> = ({
             <span className="hidden sm:inline-flex sm:ml-2">Variables</span>
             <span className="sr-only">{activeStep === 'variables' ? ' (current step)' : ''}</span>
           </li>
-          <li className={`flex items-center ${activeStep === 'preview' ? 'ndpr-text-primary' : 'ndpr-card__subtitle'}`}>
-            <span className={`flex items-center justify-center w-8 h-8 ${activeStep === 'preview' ? 'ndpr-alert ndpr-alert--info' : 'ndpr-panel'} rounded-full shrink-0`} aria-current={activeStep === 'preview' ? 'step' : undefined}>
-              3
-            </span>
-            <span className="hidden sm:inline-flex sm:ml-2">Preview</span>
-            <span className="sr-only">{activeStep === 'preview' ? ' (current step)' : ''}</span>
-          </li>
+          {showPreview && (
+            <li className={`flex items-center ${activeStep === 'preview' ? 'ndpr-text-primary' : 'ndpr-card__subtitle'}`}>
+              <span className={`flex items-center justify-center w-8 h-8 ${activeStep === 'preview' ? 'ndpr-alert ndpr-alert--info' : 'ndpr-panel'} rounded-full shrink-0`} aria-current={activeStep === 'preview' ? 'step' : undefined}>
+                3
+              </span>
+              <span className="hidden sm:inline-flex sm:ml-2">Preview</span>
+              <span className="sr-only">{activeStep === 'preview' ? ' (current step)' : ''}</span>
+            </li>
+          )}
         </ol>
       </nav>
       

--- a/packages/ndpr-toolkit/src/components/policy/PolicyPreview.tsx
+++ b/packages/ndpr-toolkit/src/components/policy/PolicyPreview.tsx
@@ -32,11 +32,23 @@ export interface PolicyPreviewProps {
   
   /**
    * The policy sections
+   *
+   * @deprecated Not read. This component renders from `content` alone and
+   * derives its table of contents by scanning that markdown for `##` and `###`
+   * headings, so passing sections has never changed the output. Kept on the type
+   * so existing call sites still compile; it will be removed in the next major.
    */
   sections?: PolicySection[];
   
   /**
    * The policy variables
+   *
+   * @deprecated Not read. `content` is expected to arrive with variables already
+   * substituted — `exportHTML`, `generatePolicyText`, and
+   * `usePrivacyPolicy().getPolicyText()` all do that — so this component has
+   * nothing left to substitute. Use `findUnfilledTokens` on the content if you
+   * need to detect tokens that escaped substitution. Kept on the type so
+   * existing call sites still compile; it will be removed in the next major.
    */
   variables?: PolicyVariable[];
   

--- a/packages/ndpr-toolkit/src/hooks/useBreach.ts
+++ b/packages/ndpr-toolkit/src/hooks/useBreach.ts
@@ -51,8 +51,14 @@ function breachReducer(state: BreachCompositeState, action: BreachAction): Breac
 export interface UseBreachOptions {
   /**
    * Available breach categories
+   *
+   * @deprecated Not read by this hook, and now optional — it was previously
+   * required, so every caller had to build an array the hook then ignored.
+   * Category lists belong to whatever UI renders the picker; pass them straight
+   * to that component instead. Kept on the type so existing call sites still
+   * compile; it will be removed in the next major.
    */
-  categories: BreachCategory[];
+  categories?: BreachCategory[];
 
   /**
    * Initial breach reports


### PR DESCRIPTION
Five props were declared on public types, documented, and **never read** by their implementations. A consumer setting any of them got silence. #130 surfaced them while clearing the CodeQL unused-variable alerts; this resolves them.

Handled on their merits rather than uniformly. **Nothing here is breaking** — no type is narrowed, no signature loses a parameter.

## Implemented: `PolicyGenerator.showPreview`

The machinery was already there — a three-step `sections`/`variables`/`preview` wizard, with `generatePolicy` ending in `setActiveStep('preview')`. Intent was unambiguous, so:

- `showPreview={false}` generates and hands the policy straight to `onGenerate`
- the step indicator drops its third entry

One subtlety worth flagging: the submit passes the local `policyContent`, **not** `generatedPolicy`/`editedPolicy`. Those `setState` calls haven't landed in the same tick, so reading them there would emit the previous — empty — content. There's a test pinning exactly that. Required-variable validation still runs first, so turning off the preview can't be used to skip validation.

## Deprecated: nothing to apply them to

| Prop | Why |
|---|---|
| `DSRTracker.buttonClassName` | Documented as "custom CSS class for the buttons", but the component renders **no buttons at all** — its only control is the timeframe `<select>`. Implementing it would mean inventing a button. `classNames` / `unstyled` are the real styling API. |
| `PolicyPreview.sections` | Redundant by construction. The component renders from `content` and builds its ToC by scanning that markdown for `##`/`###`. |
| `PolicyPreview.variables` | `content` is expected to arrive already substituted — which is what `exportHTML`, `generatePolicyText`, and `usePrivacyPolicy().getPolicyText()` all produce. `findUnfilledTokens` covers the case where it matters. |
| `useBreach({ categories })` | Worse than the others: a **required** option the hook never read, so every caller built an array purely to have it ignored. Now **optional** and deprecated. |

Making a required field optional is backwards compatible, so existing call sites — including this repo's own tests, which all still pass `categories` — keep compiling.

Each deprecation carries a `@deprecated` note explaining what to use instead, so it shows up in editor tooltips at the point of use rather than only in a changelog. All four stay on their types and are slated for removal in the next major.

## Verification

Full `pnpm verify:ci`: **117 suites / 1488 tests**, up from 116 / 1482.

Six new tests cover:
- `showPreview` default — lands on preview, emits nothing until Save
- `showPreview={false}` — emits immediately, no preview step in the indicator
- the stale-state trap — asserts the emitted content is the freshly generated text, not `''`
- validation still blocks generation when the preview is off
- `useBreach` with `categories` omitted, and still reporting a breach that way