### PR TITLE
chore(examples): move the Next examples to Next 16

### DIFF
--- a/examples/dsr-backend-reference/package.json
+++ b/examples/dsr-backend-reference/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@tantainnovative/ndpr-toolkit": "^6.0.0",
-    "next": "^15.5.18",
+    "next": "^16.2.12",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -27,6 +27,6 @@
     "typescript": "^5.0.0"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   }
 }

--- a/examples/ecommerce-starter/package.json
+++ b/examples/ecommerce-starter/package.json
@@ -11,7 +11,7 @@
     "@tantainnovative/ndpr-toolkit": "^6.0.0",
     "docx": "^9.5.1",
     "jspdf": "^4.2.1",
-    "next": "^15.5.18",
+    "next": "^16.2.12",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -22,6 +22,6 @@
     "typescript": "^5.0.0"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   }
 }

--- a/examples/nextjs-app/package.json
+++ b/examples/nextjs-app/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@tantainnovative/ndpr-toolkit": "^6.0.0",
-    "next": "^15.5.18",
+    "next": "^16.2.12",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -20,6 +20,6 @@
     "typescript": "^5.7.0"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   }
 }

--- a/examples/ssr/nextjs-app-router/package.json
+++ b/examples/ssr/nextjs-app-router/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@tantainnovative/ndpr-toolkit": "^6.0.0",
-    "next": "^15.5.18",
+    "next": "^16.2.12",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -20,6 +20,6 @@
     "typescript": "^5.0.0"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   }
 }

--- a/examples/stackblitz/breach/package.json
+++ b/examples/stackblitz/breach/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@tantainnovative/ndpr-toolkit": "^6.0.0",
-    "next": "^15.5.18",
+    "next": "^16.2.12",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -20,6 +20,6 @@
     "typescript": "^5.0.0"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   }
 }

--- a/examples/stackblitz/consent/package.json
+++ b/examples/stackblitz/consent/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@tantainnovative/ndpr-toolkit": "^6.0.0",
-    "next": "^15.5.18",
+    "next": "^16.2.12",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -20,6 +20,6 @@
     "typescript": "^5.0.0"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   }
 }

--- a/examples/stackblitz/cross-border/package.json
+++ b/examples/stackblitz/cross-border/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@tantainnovative/ndpr-toolkit": "^6.0.0",
-    "next": "^15.5.18",
+    "next": "^16.2.12",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -20,6 +20,6 @@
     "typescript": "^5.0.0"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   }
 }

--- a/examples/stackblitz/dpia/package.json
+++ b/examples/stackblitz/dpia/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@tantainnovative/ndpr-toolkit": "^6.0.0",
-    "next": "^15.5.18",
+    "next": "^16.2.12",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -20,6 +20,6 @@
     "typescript": "^5.0.0"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   }
 }

--- a/examples/stackblitz/dsr/package.json
+++ b/examples/stackblitz/dsr/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@tantainnovative/ndpr-toolkit": "^6.0.0",
-    "next": "^15.5.18",
+    "next": "^16.2.12",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -20,6 +20,6 @@
     "typescript": "^5.0.0"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   }
 }

--- a/examples/stackblitz/lawful-basis/package.json
+++ b/examples/stackblitz/lawful-basis/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@tantainnovative/ndpr-toolkit": "^6.0.0",
-    "next": "^15.5.18",
+    "next": "^16.2.12",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -20,6 +20,6 @@
     "typescript": "^5.0.0"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   }
 }

--- a/examples/stackblitz/policy/package.json
+++ b/examples/stackblitz/policy/package.json
@@ -11,7 +11,7 @@
     "@tantainnovative/ndpr-toolkit": "^6.0.0",
     "docx": "^9.0.0",
     "jspdf": "^4.2.1",
-    "next": "^15.5.18",
+    "next": "^16.2.12",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -22,6 +22,6 @@
     "typescript": "^5.0.0"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   }
 }

--- a/examples/stackblitz/ropa/package.json
+++ b/examples/stackblitz/ropa/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@tantainnovative/ndpr-toolkit": "^6.0.0",
-    "next": "^15.5.18",
+    "next": "^16.2.12",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -20,6 +20,6 @@
     "typescript": "^5.0.0"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.9.0"
   }
 }


### PR DESCRIPTION
Follow-up to #135, which moved all 14 examples to the 6.x toolkit line but left them on Next 15 — I flagged it there as a separate change.

Twelve examples pinned `next: ^15.5.18` while the toolkit itself builds on **16.2.12**, so they demonstrated 6.0 on a framework a major behind. Now matched to the root.

## `engines.node` moves too

Next 16 declares `node: >=20.9.0`. The examples claimed `>=20.0.0`, so leaving that alone would let someone on Node 20.5 install cleanly and then fail at build time. Bumped to `>=20.9.0` alongside.

Untouched: `ssr/astro` already requires `>=22.12.0`, and `ssr/remix` doesn't use Next.

## No source changes needed

Nothing in these examples used an API Next 16 changed.

## Verification

```
$ node scripts/verify-examples.mjs --build
...
14/14 examples verified
```

Plus a spot check that the bump actually takes effect rather than resolving back to 15:

```
installed next: 16.2.12
installed toolkit: 6.0.0
```