### PR TITLE
chore(release): v6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,48 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
-## Changelog taxonomy
+## [6.1.0](https://github.com/mr-tanta/ndpr-toolkit/compare/v6.0.0...v6.1.0) (2026-08-06)
 
-- **Features**: additive public APIs, components, hooks, routes, adapters, CLI behavior, or documented capabilities.
-- **Bug Fixes**: corrections to shipped behavior, validation, packaging, security hardening, or regressions.
-- **Documentation**: docs, examples, release guidance, legal citation wording, or site content that does not change package behavior.
-- **Compliance Rule Changes**: changes to NDPA/NDPC/GAID assumptions, default thresholds, filing deadlines, citation mappings, scoring semantics, or compliance-sensitive validator behavior. These entries should name the affected source and module, and should say whether users need to re-run audits, update config, refresh evidence, or seek legal review.
+A security and correctness release. Two vulnerabilities in the published package are fixed, one prop that was documented but inert now works, and four more are marked deprecated. Nothing is removed and no signature loses a parameter, so upgrading is a version bump — but read **Behavior Changes** below if you pass `showPreview`.
 
-Compliance-impacting examples:
+Released alongside `@tantainnovative/ndpr-recipes@0.4.0` and `@tantainnovative/create-ndpr@0.5.1`. The unscoped `create-ndpr@1.0.0` alias is unchanged and still delegates to the latest scoped CLI.
 
-- `Documentation`: clarify a citation block or add a stronger "not legal advice" notice.
-- `Bug Fixes`: correct a false positive in `assessBreachNotification`.
-- `Features`: add a new optional GAID check behind explicit config.
-- `Compliance Rule Changes`: update DCPMI thresholds, CAR deadlines, breach notification content assumptions, or compliance score weights because NDPC guidance changed.
+### Security
+
+* **policy export:** consumer-supplied `customCSS` could escape the `<style>` block in `exportHTML`. `<style>` is a raw-text element, so the parser ends it at the first `</style` followed by whitespace, `/`, or `>` — the previous filter matched only the literal `</style>`, letting `</style >`, `</style/>`, and `</style\n>` through as live markup. Deleting the token is also unsound because one pass can reassemble it from fragments (`</st</styleyle`). Every `<` is now escaped as the CSS escape `\3C`; `>` is untouched so child combinators still work.
+* **policy templates:** four polynomial-ReDoS sites in the `{{var}}` matchers (`findUnfilledTokens`, both `generatePolicyText` branches, and `substituteVariables`). A run of `{` was consumed in full before the closing `}}` failed, once per starting offset, so a malformed template could stall an export. The token class now excludes `{`, which fails at the first character instead.
+* **cli:** `ndpr audit --init` checked `existsSync` then wrote as a separate operation, so a file created in between was silently overwritten — defeating the "Refusing to overwrite existing" guard it exists to provide. The write now uses `wx`, making the refusal atomic.
+
+### Behavior Changes
+
+* **policy:** `PolicyGenerator`'s `showPreview` prop is now respected. It was documented with `@default true` but never read, so `showPreview={false}` still showed the preview step. Passing `false` now generates and calls `onGenerate` directly, and the step indicator drops its third entry. Required-variable validation still runs first. If you currently pass `showPreview={false}` and depend on the preview appearing anyway, remove the prop.
+* **breach:** `useBreach({ categories })` is now optional. It was required but never read, so every caller had to construct an array purely to have it ignored. Existing call sites that still pass it keep working.
+
+### Deprecations
+
+None are removed in 6.1.0; each carries a `@deprecated` note explaining what to use instead, and all are slated for removal in the next major.
+
+* `DSRTracker.buttonClassName` — the component renders no buttons, only the timeframe `<select>`. Use `classNames` or `unstyled`.
+* `PolicyPreview.sections` and `PolicyPreview.variables` — the component renders from `content` and derives its table of contents from that markdown. Use `findUnfilledTokens` if you need to detect tokens that escaped substitution.
+* `useBreach({ categories })` — pass category lists straight to whatever renders the picker.
+
+### Packages
+
+* **recipes:** the `@tantainnovative/ndpr-toolkit` peer moves from the exact `6.0.0` to `>=6.1.0 <7.0.0`. The exact pin forced a recipes republish for every toolkit patch; the range still records what it was verified against.
+* **create-ndpr:** generated scaffolds now pin `@tantainnovative/ndpr-toolkit@6.1.0`.
+
+### Bug Fixes
+
+* **cli:** close the TOCTOU race in `ndpr audit --init` ([06d23ca](https://github.com/mr-tanta/ndpr-toolkit/commit/06d23ca55a4534f7428becf5737505821b95680d))
+* **deps:** clear all 16 advisories and unblock the dependabot backlog ([e479250](https://github.com/mr-tanta/ndpr-toolkit/commit/e479250c2761f8d64fbcc0fd15c5b99dc71a7b88)), closes [#100](https://github.com/mr-tanta/ndpr-toolkit/issues/100), references [#94](https://github.com/mr-tanta/ndpr-toolkit/issues/94) [#89](https://github.com/mr-tanta/ndpr-toolkit/issues/89) [#92](https://github.com/mr-tanta/ndpr-toolkit/issues/92) [#93](https://github.com/mr-tanta/ndpr-toolkit/issues/93) [#94](https://github.com/mr-tanta/ndpr-toolkit/issues/94) [#95](https://github.com/mr-tanta/ndpr-toolkit/issues/95) [#96](https://github.com/mr-tanta/ndpr-toolkit/issues/96) [#97](https://github.com/mr-tanta/ndpr-toolkit/issues/97) [#98](https://github.com/mr-tanta/ndpr-toolkit/issues/98) [#99](https://github.com/mr-tanta/ndpr-toolkit/issues/99) [#100](https://github.com/mr-tanta/ndpr-toolkit/issues/100)
+* **deps:** record the override specifier for postcss in the lockfile ([be379f3](https://github.com/mr-tanta/ndpr-toolkit/commit/be379f3c9f89e3dd5444bcd370477559af29bd1a))
+* **examples:** clear the four astro advisories in the SSR example ([ac987ad](https://github.com/mr-tanta/ndpr-toolkit/commit/ac987ad5fc90529436eba3ce2205a2989447cc1a))
+* **policy:** make showPreview work, and mark the other dead props deprecated ([b440f64](https://github.com/mr-tanta/ndpr-toolkit/commit/b440f6492f68dcb51fe229e6ac073828e09624e4)), references [#130](https://github.com/mr-tanta/ndpr-toolkit/issues/130)
+* **security:** resolve every open CodeQL alert outside dist ([ee380d1](https://github.com/mr-tanta/ndpr-toolkit/commit/ee380d15edc49469dbe5a0ae6dc3932ff2cbb7c0))
+
+### Documentation
+
+* add 5.7 to 6.0 migration guide ([ff4d315](https://github.com/mr-tanta/ndpr-toolkit/commit/ff4d315d4930abd96efe7b0021fbfeec869f925f))
 
 ## [6.0.0](https://github.com/mr-tanta/ndpr-toolkit/compare/v5.7.4...v6.0.0) (2026-07-19)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tantainnovative/ndpr-toolkit",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "private": false,
   "packageManager": "pnpm@10.34.1",
   "description": "Nigeria Data Protection Toolkit — enterprise-grade compliance components for the Nigeria Data Protection Act (NDPA) 2023",

--- a/packages/create-ndpr/bin/index.mjs
+++ b/packages/create-ndpr/bin/index.mjs
@@ -15,7 +15,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = join(__dirname, '..', 'templates');
 const CWD = process.cwd();
 // Keep this exact pin synchronized with the repository root package version.
-const TOOLKIT_VERSION = '6.0.0';
+const TOOLKIT_VERSION = '6.1.0';
 const FORCE = process.argv.slice(2).includes('--force');
 
 const c = {

--- a/packages/create-ndpr/package.json
+++ b/packages/create-ndpr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tantainnovative/create-ndpr",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "CLI scaffolder for Nigeria NDPA 2023 / NDPC GAID 2025 compliance with @tantainnovative/ndpr-toolkit",
   "license": "MIT",
   "author": {

--- a/packages/ndpr-recipes/package.json
+++ b/packages/ndpr-recipes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tantainnovative/ndpr-recipes",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": false,
   "description": "Backend recipes for @tantainnovative/ndpr-toolkit — Prisma schemas, API routes, and ORM adapters for Nigeria NDPA 2023 / NDPC GAID 2025 compliance",
   "license": "MIT",
@@ -43,7 +43,7 @@
   "peerDependencies": {
     "@paralleldrive/cuid2": ">=3.3.0 <4.0.0",
     "@prisma/client": ">=6.19.3 <7.0.0",
-    "@tantainnovative/ndpr-toolkit": "6.0.0",
+    "@tantainnovative/ndpr-toolkit": ">=6.1.0 <7.0.0",
     "drizzle-orm": ">=0.45.2 <1.0.0",
     "express": ">=5.2.1 <6.0.0",
     "next": ">=16.2.11 <17.0.0",
@@ -78,7 +78,7 @@
   "devDependencies": {
     "@paralleldrive/cuid2": "3.3.0",
     "@prisma/client": "6.19.3",
-    "@tantainnovative/ndpr-toolkit": "workspace:6.0.0",
+    "@tantainnovative/ndpr-toolkit": "workspace:6.1.0",
     "@types/express": "5.0.6",
     "@types/node": "26.1.2",
     "@types/react": "19.2.17",

--- a/packages/ndpr-toolkit/package.json
+++ b/packages/ndpr-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tantainnovative/ndpr-toolkit",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "private": true,
   "description": "React and TypeScript compliance components for the Nigeria Data Protection Act (NDPA) 2023. NOTE: This inner package.json is NOT published — `npm publish` runs from the repo root. Marked `private: true` since 3.10.5 to make that explicit and prevent the drift class that caused the 3.8.0–3.10.2 missing-exports incident. Slated for removal in 4.0 (see plan: clear-the-audit-backlog).",
   "main": "./dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,7 +205,7 @@ importers:
         specifier: 6.19.3
         version: 6.19.3(prisma@6.19.3(typescript@6.0.3))(typescript@6.0.3)
       '@tantainnovative/ndpr-toolkit':
-        specifier: workspace:6.0.0
+        specifier: workspace:6.1.0
         version: link:../..
       '@types/express':
         specifier: 5.0.6


### PR DESCRIPTION
Coordinated release of the toolkit and both version-coupled companions.

| Package | From | To |
|---|---|---|
| `@tantainnovative/ndpr-toolkit` | 6.0.0 | **6.1.0** |
| `@tantainnovative/ndpr-recipes` | 0.3.0 | **0.4.0** |
| `@tantainnovative/create-ndpr` | 0.5.0 | **0.5.1** |
| `create-ndpr` (unscoped alias) | 1.0.0 | unchanged |

All three land in **one commit** because `publish.yml` checks out the release tag and publishes each package from that tree — a companion left behind would ship pointing at 6.0.0. The unscoped alias delegates to the latest scoped CLI via `npx`, so it has no version coupling and the workflow skips it.

## Why minor, not patch

Every commit since v6.0.0 is `fix:`, which the conventional-commit tooling scores as 6.0.1. But `showPreview` now being respected changes observable behavior for anyone passing `showPreview={false}`, `useBreach({ categories })` relaxes from required to optional, and four props gain deprecation notices. A patch would understate that. Nothing is breaking.

## What ships to the published package

Two real vulnerabilities:

- **`exportHTML` style-block escape** — consumer `customCSS` could break out via `</style >`, `</style/>`, or `</style\n>`, since the filter matched only the literal `</style>`. Deleting the token is also unsound because one pass can reassemble it from fragments (`</st</styleyle`). Now every `<` is escaped as the CSS escape `\3C`, leaving `>` intact for child combinators.
- **Four polynomial-ReDoS sites** in the `{{var}}` matchers — a run of `{` was consumed in full before the closing `}}` failed, once per starting offset, so a malformed template could stall an export.
- Plus the `ndpr audit --init` TOCTOU, where `existsSync`-then-write let a file created in between be silently overwritten, defeating the overwrite guard.

## Companion coupling fixed, not just retargeted

- recipes peered on the toolkit at **exactly `6.0.0`**, forcing a republish for every toolkit patch. Now `>=6.1.0 <7.0.0` — still records what it was verified against, without the treadmill.
- the recipes devDependency was `workspace:6.0.0`, which **stops resolving** the moment the root package becomes 6.1.0. This is why the bump couldn't be a separate later commit.
- `create-ndpr`'s `TOOLKIT_VERSION` is what generated scaffolds pin and what the post-scaffold install instructions print, so it moves too.

## Changelog

Expanded beyond the generated entry, following the v6.0.0 precedent: the two vulnerabilities are described with their actual bypasses, the `showPreview` behavior change is called out for anyone relying on the old inert prop, and each deprecation says what to use instead.

## Verification on this exact tree

- Full `pnpm verify:ci` — 117 suites / 1488 tests, lint, `build:lib`, `typecheck:recipes`, `tsc --noEmit`, 15 create-ndpr scaffold combinations, Storybook typecheck and build, and the 22-subpath tarball probe now packing `tantainnovative-ndpr-toolkit-6.1.0.tgz`
- `pnpm build:recipes` — the companion build the publish workflow runs
- `pnpm install --frozen-lockfile` — confirms the relock with `workspace:6.1.0`

## After merge

Tag the merge commit `v6.1.0` (matching v6.0.0, which points at the merge of #101), push it, then publish the GitHub Release — that's what triggers `publish.yml` to build from the tag and push all three packages via Trusted Publishing with `--provenance`.